### PR TITLE
pulumi: Update on pushes, track changes by hashing the project

### DIFF
--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -77,13 +77,18 @@ jobs:
         run: yarn install --immutable
         working-directory: pulumi
 
-      - name: Pulumi preview
+      - name: Run pulumi
         uses: pulumi/actions@18b5a33fc447ab919feb61f2bb41147a1b30ab40 # v5.2.4
         with:
           cloud-url:
             s3://${{ env.STATE_BUCKET }}?region=${{ env.AWS_REGION }}&awssdk=v2
           stack-name: organization/lambda-rssfilter/dev
-          command: preview
+          command: >
+            ${{
+              (github.event_name == 'push' && github.ref == 'refs/heads/main')
+              && 'up'
+              || 'preview'
+            }}
           comment-on-pr: true
           comment-on-summary: true
           work-dir: pulumi

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@eslint/js": "^9.5.0",
     "@types/archiver": "^6.0.2",
+    "@types/folder-hash": "^4.0.4",
     "@types/node": "^20.14.2",
     "@types/readable-stream": "^4",
     "@typescript-eslint/parser": "^7.13.0",
@@ -27,6 +28,7 @@
     "@pulumiverse/gandi": "^0.0.14",
     "@root/walk": "^1.1.0",
     "archiver": "^7.0.1",
+    "folder-hash": "^4.0.4",
     "mime": "^4.0.3",
     "readable-stream": "^4.5.2"
   },

--- a/pulumi/yarn.lock
+++ b/pulumi/yarn.lock
@@ -677,7 +677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/pulumi@npm:^3.0.0":
+"@pulumi/pulumi@npm:^3.0.0, @pulumi/pulumi@npm:^3.113.0, @pulumi/pulumi@npm:^3.42.0":
   version: 3.120.0
   resolution: "@pulumi/pulumi@npm:3.120.0"
   dependencies:
@@ -720,52 +720,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/b08ad02fa5f90ab8543021527dfdc2255643ff0aabb67d43b95cef9a926457561c234109a4b398891fa02a4bad644560f253d15e5965a3f84a46930f3025f6e8
-  languageName: node
-  linkType: hard
-
-"@pulumi/pulumi@npm:^3.113.0, @pulumi/pulumi@npm:^3.42.0":
-  version: 3.119.0
-  resolution: "@pulumi/pulumi@npm:3.119.0"
-  dependencies:
-    "@grpc/grpc-js": "npm:^1.10.1"
-    "@logdna/tail-file": "npm:^2.0.6"
-    "@npmcli/arborist": "npm:^7.3.1"
-    "@opentelemetry/api": "npm:^1.2.0"
-    "@opentelemetry/exporter-zipkin": "npm:^1.6.0"
-    "@opentelemetry/instrumentation": "npm:^0.32.0"
-    "@opentelemetry/instrumentation-grpc": "npm:^0.32.0"
-    "@opentelemetry/resources": "npm:^1.6.0"
-    "@opentelemetry/sdk-trace-base": "npm:^1.6.0"
-    "@opentelemetry/sdk-trace-node": "npm:^1.6.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.6.0"
-    "@pulumi/query": "npm:^0.3.0"
-    "@types/google-protobuf": "npm:^3.15.5"
-    "@types/semver": "npm:^7.5.6"
-    "@types/tmp": "npm:^0.2.6"
-    execa: "npm:^5.1.0"
-    fdir: "npm:^6.1.1"
-    google-protobuf: "npm:^3.5.0"
-    got: "npm:^11.8.6"
-    ini: "npm:^2.0.0"
-    js-yaml: "npm:^3.14.0"
-    minimist: "npm:^1.2.6"
-    normalize-package-data: "npm:^6.0.0"
-    picomatch: "npm:^3.0.1"
-    pkg-dir: "npm:^7.0.0"
-    require-from-string: "npm:^2.0.1"
-    semver: "npm:^7.5.2"
-    source-map-support: "npm:^0.5.6"
-    tmp: "npm:^0.2.1"
-    upath: "npm:^1.1.0"
-  peerDependencies:
-    ts-node: ">= 7.0.1 < 12"
-    typescript: ">= 3.8.3 < 6"
-  peerDependenciesMeta:
-    ts-node:
-      optional: true
-    typescript:
-      optional: true
-  checksum: 10c0/5ad414949fc4839827f3b97ccbf90e6758154eef4d3def609d464bcb1c026fd41b65b8539f19d13e868750a69965e59e8f8c3a05cef2f3c40fbec73c744f58c3
   languageName: node
   linkType: hard
 
@@ -929,6 +883,13 @@ __metadata:
     "@types/node": "npm:*"
     "@types/responselike": "npm:^1.0.0"
   checksum: 10c0/10816a88e4e5b144d43c1d15a81003f86d649776c7f410c9b5e6579d0ad9d4ca71c541962fb403077388b446e41af7ae38d313e46692144985f006ac5e11fa03
+  languageName: node
+  linkType: hard
+
+"@types/folder-hash@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@types/folder-hash@npm:4.0.4"
+  checksum: 10c0/dfef81bbd4bd807f6182cf97796c3c9e404298c9bc224d6a12d954b64b9b1f56de120fa8a12eae8e3b49504037dee4c33695762175fa200bd26768b4907707ce
   languageName: node
   linkType: hard
 
@@ -1686,7 +1647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
   dependencies:
@@ -2174,6 +2135,18 @@ __metadata:
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
+  languageName: node
+  linkType: hard
+
+"folder-hash@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "folder-hash@npm:4.0.4"
+  dependencies:
+    debug: "npm:^4.3.3"
+    minimatch: "npm:~5.1.2"
+  bin:
+    folder-hash: bin/folder-hash
+  checksum: 10c0/ff62d3ad9c34fc3f8d3e52b2a6ec67f32c8d822cecce3af148e569f1c77fba04d2a35f01a2f08bd426ca060c518258a1d952951b0e4ab4e79f0503c1dd6bed44
   languageName: node
   linkType: hard
 
@@ -2740,6 +2713,7 @@ __metadata:
     "@pulumiverse/gandi": "npm:^0.0.14"
     "@root/walk": "npm:^1.1.0"
     "@types/archiver": "npm:^6.0.2"
+    "@types/folder-hash": "npm:^4.0.4"
     "@types/node": "npm:^20.14.2"
     "@types/readable-stream": "npm:^4"
     "@typescript-eslint/parser": "npm:^7.13.0"
@@ -2748,6 +2722,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-unicorn: "npm:^54.0.0"
+    folder-hash: "npm:^4.0.4"
     mime: "npm:^4.0.3"
     prettier: "npm:^3.3.2"
     readable-stream: "npm:^4.5.2"
@@ -2958,7 +2933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.1.0":
+"minimatch@npm:^5.1.0, minimatch@npm:~5.1.2":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
   dependencies:


### PR DESCRIPTION
This change updates the Pulumi workflow to run `pulumi up` on pushes to `main` and `pulumi preview` on other branches. It also changes the `ZippedRustBinary` resource to track changes by hashing the project directory instead of the last modified file. This is because `git` doesn't track the last modified time of files, so it's not a reliable way to determine if the project has changed.