### PR TITLE
Dependabot bumps

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -1,6 +1,6 @@
 FROM ghcr.io/iainlane/dotfiles-rust-tools:git-24a7c0cfa3e9b909f954a85dd0b4163f6009f02d AS rust-tools
 
-FROM public.ecr.aws/aws-cli/aws-cli:2.16.3 AS aws-cli
+FROM public.ecr.aws/aws-cli/aws-cli:2.16.10 AS aws-cli
 
 FROM pulumi/pulumi-base:3.119.0 AS pulumi
 


### PR DESCRIPTION
Bumps aws-cli/aws-cli from 2.16.3 to 2.16.10.

---
updated-dependencies:
- dependency-name: aws-cli/aws-cli dependency-type: direct:production update-type: version-update:semver-patch ...