### PR TITLE
pulumi: Set up cross toolchain when pushing to main

### DIFF
--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -62,6 +62,15 @@ jobs:
       - name: Check out
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Set up cross toolchain
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/build
+        with:
+          # will be built in pulumi
+          build: false
+          pkg-config-sysroot: /usr/lib/aaarch64-linux-gnu
+          target: aaarch64-unknown-linux-gnu
+
       - name: Enable corepack
         run: |
           corepack enable


### PR DESCRIPTION
We build the project for arm64 in here, so we need the cross toolchain available.
