### PR TITLE
pulumi: Set PKG_CONFIG_SYSROOT_DIR for aarch64

### DIFF
--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Run pulumi
         uses: pulumi/actions@18b5a33fc447ab919feb61f2bb41147a1b30ab40 # v5.2.4
+        env:
+          PKG_CONFIG_SYSROOT_DIR: /usr/lib/aarch64-linux-gnu
         with:
           cloud-url:
             s3://${{ env.STATE_BUCKET }}?region=${{ env.AWS_REGION }}&awssdk=v2


### PR DESCRIPTION
Since we're building here and not in the `build` step, we need to set this
environment variable to point to the sysroot so that pkg-config can find the
right files.
