### PR TITLE
build/oidc: Add prod stack, build in cache

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,10 +1,10 @@
 name: Build
 description: Build the project
 inputs:
-  build:
-    description: Whether to build the project
-    required: false
-    default: 'true'
+  build-type:
+    description: The type of build to perform (release or debug)
+    required: true
+    default: "release"
   pkg-config-sysroot:
     description: The sysroot to use for pkg-config
     required: true
@@ -15,20 +15,42 @@ inputs:
   target-dir:
     description: The directory to build the project in
     required: true
-    default: ''
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
 
   steps:
+    - name: Cache
+      id: cache
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key:
+          build-cargo-${{ runner.os }}-${{ inputs.target }}-${{
+          inputs.build-type }}-${{ hashFiles('**/Cargo.lock','**/*.rs') }}
+        restore-keys: |
+          build-cargo-${{ runner.os }}-${{ inputs.target }}-${{ inputs.build-type }}-
+          build-cargo-${{ runner.os }}-${{ inputs.target }}-
+          build-cargo-${{ runner.os }}-
+
     - name: Set Rust toolchain up
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
       with:
+        components: rustfmt
         target: ${{ inputs.target }}
 
     - name: Install cross toolchain
+      if:
+        inputs.target == 'aarch64-unknown-linux-gnu' &&
+        steps.cache.outputs.cache-hit != 'true'
       shell: sh
-      if: inputs.target == 'aarch64-unknown-linux-gnu'
       run: |
         # Set up apt sources for arm64
 
@@ -61,8 +83,12 @@ runs:
         EOF
 
     - name: Build
-      if: ${{ fromJSON(inputs.build) }}
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: sh
       env:
         PKG_CONFIG_SYSROOT_DIR: ${{ inputs.pkg-config-sysroot }}
-      run: cargo build --target ${{ inputs.target }} ${{ inputs.target-dir && format('--target-dir {}', inputs.target-dir) || ''}}
+      run: |
+        cargo build \
+          --target ${{ inputs.target }} \
+          ${{ inputs.build-type == 'release' && '--release' || ''}} \
+          ${{ inputs.target-dir && format('--target-dir {}', inputs.target-dir) || ''}}

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -16,7 +16,14 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             sysroot: /usr/lib/aarch64-linux-gnu
 
-    name: Build
+    # Share build results via cache
+    concurrency:
+      group:
+        build-${{ github.event_name }}-${{ github.sha }}-${{
+        matrix.config.target }}
+      cancel-in-progress: false
+
+    name: Build, test, format
     runs-on: ubuntu-24.04
 
     steps:
@@ -26,33 +33,14 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
+          build-type:
+            ${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
           pkg-config-sysroot: ${{ matrix.config.sysroot }}
           target: ${{ matrix.config.target }}
 
-  test:
-    name: cargo test
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set Rust toolchain up
-        uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
-
       - name: Run tests
+        if: matrix.config.target == 'x86_64-unknown-linux-gnu'
         run: cargo test --all-features
-
-  formatting:
-    name: cargo fmt
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set Rust toolchain up
-        uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
-        with:
-          components: rustfmt
 
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@2d1d4e9f72379428552fa1def0b898733fb8472d # v1.1.0

--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -31,6 +31,13 @@ jobs:
           audience: "${{ github.server_url }}/${{ github.repository_owner }}"
 
   pulumi:
+    # Share build results via cache
+    concurrency:
+      group:
+        build-${{ github.event_name }}-${{ github.sha
+        }}-aarch64-unknown-linux-gnu
+      cancel-in-progress: false
+
     name: Pulumi
 
     permissions:
@@ -42,15 +49,15 @@ jobs:
 
     env:
       AWS_REGION: eu-west-2
-      ROLE_PUSH: arn:aws:iam::588722779806:role/oidcPushRole-3c5a11f
-      ROLE_PULL_REQUEST: arn:aws:iam::588722779806:role/oidcPullRequestRole-d7be9a3
+      ROLE_PULL_REQUEST: arn:aws:iam::588722779806:role/oidcPullRequestRole-f06bda4
+      ROLE_PUSH: arn:aws:iam::588722779806:role/oidcPushRole-3ed1aa1
       STATE_BUCKET: pulumi-state-588722779806
 
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          audience: lambda-rssfilter-dev
+          audience: lambda-rssfilter-core-prod
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume:
             ${{ github.event_name == 'push' && env.ROLE_PUSH ||
@@ -62,12 +69,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Set up cross toolchain
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Build
         uses: ./.github/actions/build
         with:
-          # will be built in pulumi
-          build: false
+          build-type:
+            ${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
           pkg-config-sysroot: /usr/lib/aarch64-linux-gnu
           target: aarch64-unknown-linux-gnu
 
@@ -93,8 +99,8 @@ jobs:
         with:
           cloud-url:
             s3://${{ env.STATE_BUCKET }}?region=${{ env.AWS_REGION }}&awssdk=v2
-          stack-name: organization/lambda-rssfilter/dev
-          command: >
+          stack-name: organization/lambda-rssfilter/prod
+          command: >-
             ${{
               (github.event_name == 'push' && github.ref == 'refs/heads/main')
               && 'up'

--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -2,4 +2,4 @@ secretsprovider: awskms://alias/pulumi-state
 encryptedkey: AQICAHiv+Gm5B8HVGKlNucFxKzCclUZy2PL9ZEOxDXa/c6y1gAEjpe+SLsse8uxvNwEklCmEAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2gRfubpEbQ2kqBC0AgEQgDux+HTD9f1NQVwSoLLUF2YJPY/z/tpI7nqnXhoR7MxQfDAegmMLiTK1j57/jeEmIvQs6Ufg5PjFYFyBPw==
 config:
   aws-native:region: eu-west-2
-  lambda-rssfilter:subdomain: dev.rssfilter
+  lambda-rssfilter:subdomain: rssfilter

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -4,6 +4,10 @@
   "engines": {
     "node": "22"
   },
+  "private": true,
+  "workspaces": [
+    "core"
+  ],
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^9.6.0",

--- a/pulumi/src/api-gateway.ts
+++ b/pulumi/src/api-gateway.ts
@@ -2,6 +2,9 @@ import * as aws from "@pulumi/aws-native";
 import * as awsclassic from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
+import type { CreatedResources as LambdaResources } from "./lambda";
+import type { CreatedResources as CertificateResources } from "./dns-tls";
+
 export interface CreatedResources {
   apiGateway: awsclassic.apigatewayv2.Api;
   apiGatewayDomain: awsclassic.apigatewayv2.DomainName;
@@ -12,11 +15,8 @@ export interface CreatedResources {
 
 export function createApiGateway(
   name: string,
-  lambda: aws.lambda.Function,
-  certificate: {
-    domainName: pulumi.Output<string>;
-    arn: pulumi.Output<string>;
-  },
+  { lambda }: LambdaResources,
+  { certificate, certificateValidation }: CertificateResources,
 ): CreatedResources & { targetUrl: pulumi.Output<string> } {
   const apiGateway = new awsclassic.apigatewayv2.Api(name, {
     protocolType: "HTTP",
@@ -61,7 +61,7 @@ export function createApiGateway(
     {
       domainName: certificate.domainName,
       domainNameConfiguration: {
-        certificateArn: certificate.arn,
+        certificateArn: certificateValidation.certificateArn,
         endpointType: "REGIONAL",
         securityPolicy: "TLS_1_2",
       },

--- a/pulumi/src/dns-tls.ts
+++ b/pulumi/src/dns-tls.ts
@@ -27,7 +27,7 @@ export function validatedCertificate(
 ): CreatedResources {
   const domainNameFull = `${subdomain}.${zone}`;
 
-  const certificate = new awsclassic.acm.Certificate(`${domainNameFull}-cert`, {
+  const certificate = new awsclassic.acm.Certificate("lambda-rssfilter-cert", {
     domainName: domainNameFull,
     validationMethod: "DNS",
   });
@@ -44,7 +44,7 @@ export function validatedCertificate(
   };
 
   const certificateValidationRecord = new gandi.livedns.Record(
-    `${domainNameFull}-cert-validation`,
+    "lambda-rssfilter-cert-validation",
     {
       ...validationOptions,
       zone,
@@ -56,7 +56,7 @@ export function validatedCertificate(
   );
 
   const certificateValidation = new awsclassic.acm.CertificateValidation(
-    "certificateValidation",
+    "lambda-rssfilter-cert-validation",
     {
       certificateArn: certificate.arn,
       validationRecordFqdns: [validationOptions.fqdn],
@@ -78,7 +78,7 @@ export function cnameRecord(
   target: Output<string> | string,
 ) {
   return new gandi.livedns.Record(
-    `${subdomain}-cname`,
+    "lambda-rssfilter-cname",
     {
       zone,
       ttl: 300,

--- a/pulumi/src/index.ts
+++ b/pulumi/src/index.ts
@@ -13,16 +13,21 @@ import { key, storageBucket, versionId } from "./build-upload";
 import { appName, domainName, subdomain } from "./config";
 import { cnameRecord, validatedCertificate } from "./dns-tls";
 import { createLambda } from "./lambda";
-import { createOidcPushPolicies, oidc } from "./oidc";
+import {
+  createOidcPushPolicies,
+  createOidcPullRequestPolicies,
+  oidc,
+} from "./oidc";
 
-const { certificate } = validatedCertificate(subdomain, domainName);
+const cert = validatedCertificate(subdomain, domainName);
 
-const { lambda } = await createLambda(appName, storageBucket, key, versionId);
+const lambda = await createLambda(appName, storageBucket, key, versionId);
 
-const { targetUrl } = createApiGateway(appName, lambda, certificate);
+const { targetUrl } = createApiGateway(appName, lambda, cert);
 
 cnameRecord(subdomain, domainName, targetUrl);
+createOidcPullRequestPolicies(lambda);
 createOidcPushPolicies(storageBucket);
 
-export { oidc };
 export const fqdn = `https://${subdomain}.${domainName}`;
+export { oidc };

--- a/pulumi/src/oidc.ts
+++ b/pulumi/src/oidc.ts
@@ -11,32 +11,27 @@ import type { CreatedResources as DNSTLSResources } from "./dns-tls";
 import type { CreatedResources as LambdaResources } from "./lambda";
 
 import { gitHubRepo } from "./config";
-import { Resource } from "@pulumi/aws-native/apigateway";
 
 const accountId = (await aws.getAccountId()).accountId;
+const coreStack = new pulumi.StackReference(
+  "organization/lambda-rssfilter-core/shared",
+);
 const region = (await aws.getRegion()).region;
-
-const projectName = pulumi.getProject();
 const stack = pulumi.getStack();
 
 const oidcAudience = "token.actions.githubusercontent.com";
-const oidcProvider = new aws.iam.OidcProvider("gitHub-oidc", {
-  clientIdList: [`${projectName}-${stack}`],
-  thumbprintList: [
-    // gitHub's thumbprints as of 2024-06-06. According to AWS's documentation,
-    // these aren't used for validation.
-    "6938fd4d98bab03faadb97b34396831e3780aea1",
-    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
-  ],
-  url: `https://${oidcAudience}`,
-});
+
+const oidcProvider = coreStack
+  .getOutput("oidcProviderArn")
+  .apply(async (arn: string) => aws.iam.getOidcProvider({ arn }));
 
 // A map of the audience to the client ID, used in the role's trust policy to
 // ensure that only this OIDC provider can assume the role.
-const audiences = oidcProvider.clientIdList.apply(
-  (ids) =>
-    ids && Object.fromEntries(ids.map((id) => [`${oidcAudience}:aud`, id])),
-);
+const clientIds = coreStack.getOutput("clientIds");
+
+const audience = clientIds.apply((ids: { [key: string]: string }) => ({
+  [`${oidcAudience}:aud`]: ids[stack],
+}));
 
 /**
  * The role that Actions workflows will assume when running for pull requests.
@@ -52,8 +47,8 @@ const oidcPullRequestRole = new aws.iam.Role("oidcPullRequestRole", {
         },
         Action: "sts:AssumeRoleWithWebIdentity",
         Condition: {
-          StringEquals: audiences.apply((audiences) => ({
-            ...audiences,
+          StringEquals: audience.apply((audience) => ({
+            ...audience,
             [`${oidcAudience}:sub`]: `repo:${gitHubRepo}:pull_request`,
           })),
         },
@@ -65,7 +60,7 @@ const oidcPullRequestRole = new aws.iam.Role("oidcPullRequestRole", {
 /**
  * The role that Actions workflows will assume when running for pushes.
  */
-const oidcPush = new aws.iam.Role("oidcPushRole", {
+const oidcPushRole = new aws.iam.Role("oidcPushRole", {
   assumeRolePolicyDocument: {
     Version: "2012-10-17",
     Statement: [
@@ -76,8 +71,8 @@ const oidcPush = new aws.iam.Role("oidcPushRole", {
         },
         Action: "sts:AssumeRoleWithWebIdentity",
         Condition: {
-          StringEquals: audiences.apply((audiences) => ({
-            ...audiences,
+          StringEquals: audience.apply((audience) => ({
+            ...audience,
             [`${oidcAudience}:sub`]: `repo:${gitHubRepo}:ref:refs/heads/main`,
           })),
         },
@@ -97,95 +92,91 @@ const stateBucketKeyAlias = aws.kms.Alias.get(
 const stateBucketKey = aws.kms.Key.get(
   "stateBucketKey",
   stateBucketKeyAlias.targetKeyId,
+  {
+    ignoreChanges: [
+      "bypassPolicyLockoutSafetyCheck",
+      "pendingWindowInDays",
+      "rotationPeriodInDays",
+    ],
+  },
 );
 
-const oidcPullRequestPolicies = [
-  // read from and write to the state bucket
-  new aws.iam.ManagedPolicy("stateBucketPolicy", {
-    description: "Allow read/write to the Pulumi state bucket",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Action: ["s3:ListBucket", "s3:GetBucketLocation"],
-          Resource: stateBucket.arn,
-        },
-        {
-          Effect: "Allow",
-          Action: ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"],
-          Resource: `${stateBucket.arn}/*`,
-        },
-      ],
-    },
-    roles: [oidcPullRequestRole.id, oidcPush.id],
-  }),
-
-  // decrypt the kms key used to encrypt secrets in the state bucket
-  new aws.iam.ManagedPolicy("kmsReadOnlyPolicy", {
-    description:
-      "Allow read access to the KMS key used to encrypt the Pulumi state bucket",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Action: ["kms:Decrypt"],
-          Resource: stateBucketKey.arn,
-        },
-        {
-          Effect: "Allow",
-          Action: ["kms:DescribeKey"],
-          Resource: `arn:aws:kms:${region}:${accountId}:key/*`,
-        },
-        {
-          Effect: "Allow",
-          Action: ["kms:ListAliases", "kms:ListKeys"],
-          Resource: "*",
-        },
-      ],
-    },
-    roles: [oidcPullRequestRole.id, oidcPush.id],
-  }),
-
-  // we have a Gandi API key in SSM parameter store
-  new aws.iam.ManagedPolicy("ssmReadOnlyPolicy", {
-    description: "Allow read access to the Gandi API key",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Action: ["ssm:GetParameter"],
-          Resource: `arn:aws:ssm:${region}:${accountId}:parameter/lambda-rssfilter/gandi-key`,
-        },
-      ],
-    },
-    roles: [oidcPullRequestRole.id, oidcPush.id],
-  }),
-
-  // pulumi uses the cloud control api to execute changes
-  new aws.iam.ManagedPolicy("cloudControlGetResourcesPolicy", {
-    description: "Allow read access to CloudFormation resources",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Action: ["cloudformation:GetResource"],
-          Resource: "*",
-        },
-      ],
-    },
-    roles: [oidcPullRequestRole.id, oidcPush.id],
-  }),
-];
+export function createOidcPullRequestPolicies({ lambda }: LambdaResources) {
+  return [
+    // read from and write to the state bucket
+    new aws.iam.ManagedPolicy("stateBucketPolicy", {
+      description: "Allow read/write to the Pulumi state bucket",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["s3:ListBucket", "s3:GetBucketLocation"],
+            Resource: stateBucket.arn,
+          },
+          {
+            Effect: "Allow",
+            Action: ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"],
+            Resource: `${stateBucket.arn}/*`,
+          },
+          // Allow read access to the KMS key used to encrypt the Pulumi state bucket
+          {
+            Effect: "Allow",
+            Action: ["kms:Decrypt"],
+            Resource: stateBucketKey.arn,
+          },
+          {
+            Effect: "Allow",
+            Action: ["kms:DescribeKey"],
+            Resource: `arn:aws:kms:${region}:${accountId}:key/*`,
+          },
+          {
+            Effect: "Allow",
+            Action: ["kms:ListAliases", "kms:ListKeys"],
+            Resource: "*",
+          },
+          // we have a Gandi API key in SSM parameter store
+          // Allow read access to the Gandi API key"
+          {
+            Effect: "Allow",
+            Action: ["ssm:GetParameter"],
+            Resource: `arn:aws:ssm:${region}:${accountId}:parameter/lambda-rssfilter/gandi-key`,
+          },
+          // pulumi uses the cloud control api to execute changes
+          {
+            Effect: "Allow",
+            Action: ["cloudformation:GetResource"],
+            Resource: "*",
+          },
+          // Allow read access to the lambda function"
+          {
+            Effect: "Allow",
+            Action: ["lambda:GetFunction"],
+            Resource: lambda.arn,
+          },
+          // Allow read access to IAM roles"
+          {
+            Effect: "Allow",
+            Action: ["iam:GetRolePolicy"],
+            Resource: "*",
+          },
+          // Allow read access to the OIDC provider"
+          {
+            Effect: "Allow",
+            Action: ["iam:GetOpenIDConnectProvider"],
+            Resource: oidcProvider.arn,
+          },
+        ],
+      },
+      roles: [oidcPullRequestRole.id, oidcPushRole.id],
+    }),
+  ];
+}
 
 // policies for only the push role. It can do everything the pull request role
 // can do, because it's included in the managed policies above. But it can also
 // create-update-delete the resources themselves. IOW, we can preview for PRs
 // and apply for pushes.
-
 export function createOidcPushPolicies(
   storageBucket: aws.s3.Bucket,
 ): aws.iam.ManagedPolicy {
@@ -218,14 +209,15 @@ export function createOidcPushPolicies(
         },
       ],
     },
-    roles: [oidcPush.id],
+    roles: [oidcPushRole.id],
   });
 }
 
 export const oidc = {
   audience: oidcProvider.clientIdList,
+  oidcProviderArn: oidcProvider.arn,
   roleArns: {
     pullRequests: oidcPullRequestRole.arn,
-    pushes: oidcPush.arn,
+    pushes: oidcPushRole.arn,
   },
 };


### PR DESCRIPTION
The build is slow, and we're currently iterating on the OIDC setup. This slowness means that iterating is taking a long time. Since we build the Rust binary in CI anyway, we can share the results between the build test and the deploy job.

Additionally, we're adding a prod stack which will be used to deploy the application to a production environment from CI. This should let us test and manually apply locally and then deploy to production from CI.

Finally, update one or two policies to add permissions we've already seen we need.
