### PR TITLE
OIDC: Add s3:GetObjectVersion permission to the OIDC role

### DIFF
--- a/pulumi/src/oidc.ts
+++ b/pulumi/src/oidc.ts
@@ -205,6 +205,7 @@ export function createOidcPushPolicies(
             "s3:DeleteObject",
             "s3:GetObject",
             "s3:GetObjectTagging",
+            "s3:GetObjectVersion",
             "s3:PutObject",
           ],
           Resource: pulumi.interpolate`${storageBucket.arn}/*`,


### PR DESCRIPTION
Needed as the Lambda gets its code from S3 and we need to be able to read the version to update the function when the code bundle changes.
