### PR TITLE
CI: Don't run build/deploy jobs concurrently on pushes

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -16,11 +16,20 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             sysroot: /usr/lib/aarch64-linux-gnu
 
-    # Share build results via cache
+    # Share build results via cache between the `build-rust.yml` and `oidc.yml`
+    # workflows, because they have the same concurrency group.
+    #
+    # For pull requests, the concurrency group is based on the pull request's
+    # SHA. For pushes, the concurrency group is based on the branch name. This
+    # allows the workflows to run concurrently for different branches, but not
+    # for the same branch. When we run for pushes, we actually deploy the
+    # infrastructure, so we don't want jobs to run concurrently.
     concurrency:
-      group:
-        build-${{ github.event_name }}-${{ github.sha }}-${{
-        matrix.config.target }}
+      group: >-
+        build-${{
+          github.event_name == 'pull_request' &&
+          github.sha ||
+        github.ref }}-${{ matrix.config.target }}
       cancel-in-progress: false
 
     name: Build, test, format

--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -31,11 +31,20 @@ jobs:
           audience: "${{ github.server_url }}/${{ github.repository_owner }}"
 
   pulumi:
-    # Share build results via cache
+    # Share build results via cache between the `build-rust.yml` and `oidc.yml`
+    # workflows, because they have the same concurrency group.
+    #
+    # For pull requests, the concurrency group is based on the pull request's
+    # SHA. For pushes, the concurrency group is based on the branch name. This
+    # allows the workflows to run concurrently for different branches, but not
+    # for the same branch. When we run for pushes, we actually deploy the
+    # infrastructure, so we don't want jobs to run concurrently.
     concurrency:
-      group:
-        build-${{ github.event_name }}-${{ github.sha
-        }}-aarch64-unknown-linux-gnu
+      group: >-
+        build-${{
+          github.event_name == 'pull_request' &&
+          github.sha ||
+        github.ref }}-aarch64-unknown-linux-gnu
       cancel-in-progress: false
 
     name: Pulumi


### PR DESCRIPTION
Currently each job tries to run concurrently, because we consider each commit its own unit. But when multiple pushes happen in quick succession, the jobs will run concurrently and may interfere with each other. This is especially problematic for the deploy job, which can only be run by one job at a time since it - correctly - takes a lock.

Fix this by still allowing concurrent builds for PRs, but serialising the build/deploy jobs for pushes.
