### PR TITLE
CI: Run `setup-rust-toolchain` from fork with cache key support

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,6 +9,11 @@
       "version": "1.5.0",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:a124954d7ed085eb90e08e6fcecac8cbcbb866317ab16deb2c7797d63cbf35d6",
       "integrity": "sha256:a124954d7ed085eb90e08e6fcecac8cbcbb866317ab16deb2c7797d63cbf35d6"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.2.0",
+      "resolved": "ghcr.io/devcontainers/features/rust@sha256:87e1306eef9c1bbc3896e65af91c520f2e78f520d1c2e183ee27c2b11a9397ef",
+      "integrity": "sha256:87e1306eef9c1bbc3896e65af91c520f2e78f520d1c2e183ee27c2b11a9397ef"
     }
   }
 }

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -41,10 +41,15 @@ runs:
 
     - name: Set Rust toolchain up
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      # uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      # Run from fork which contains
+      # https://github.com/actions-rust-lang/setup-rust-toolchain/pull/41 to
+      # allow us to disamgiuate cache keys when running in multiple jobs
+      uses: iainlane/setup-rust-toolchain@d4e530262382bb10ab572c928e42bf70b5bec312
       with:
         components: rustfmt
         target: ${{ inputs.target }}
+        key: ${{ runner.os }}-${{ inputs.target }}
 
     - name: Install cross toolchain
       if:


### PR DESCRIPTION
We run the build for amd64 and arm64, and we use `setup-rust-toolchain` to install and cache the Rust toolchain and project dependencies.

The caching part of that action doesn't currently work if it's run in multiple jobs from the same workflow run. The cache key doesn't contain anything that would disambiguate and there is no input to `setup-rust-toolchain` to allow it to be customised.

To fix that, I've just [submitted a PR][PR] to the action to allow the cache key to be customised. This will allow us to set a key that includes the OS and architecture of the build, so that the caches are kept separate. We're making use of that here.

[PR]: https://github.com/actions-rust-lang/setup-rust-toolchain/pull/41
