### PR TITLE
build: Fix caching of resulting binaries

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,6 +1,9 @@
 name: Build
 description: Build the project
 inputs:
+  always-restore-build-cache:
+    description: Always restore the build cache, even if we're not rebuilding
+    required: false
   build-type:
     description: The type of build to perform (release or debug)
     required: true
@@ -21,40 +24,39 @@ runs:
   using: "composite"
 
   steps:
-    - name: Cache
-      id: cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - name: Restore cache
+      id: restore-cache
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key:
+          target/release/**
+          target/*/release/**
+        key: >
           build-cargo-${{ runner.os }}-${{ inputs.target }}-${{
           inputs.build-type }}-${{ hashFiles('**/Cargo.lock','**/*.rs') }}
-        restore-keys: |
-          build-cargo-${{ runner.os }}-${{ inputs.target }}-${{ inputs.build-type }}-
-          build-cargo-${{ runner.os }}-${{ inputs.target }}-
-          build-cargo-${{ runner.os }}-
 
     - name: Set Rust toolchain up
-      if: steps.cache.outputs.cache-hit != 'true'
-      # uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
-      # Run from fork which contains
-      # https://github.com/actions-rust-lang/setup-rust-toolchain/pull/41 to
-      # allow us to disamgiuate cache keys when running in multiple jobs
-      uses: iainlane/setup-rust-toolchain@d4e530262382bb10ab572c928e42bf70b5bec312
+      uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
       with:
+        cache: false
         components: rustfmt
         target: ${{ inputs.target }}
+
+    - name: Set Rust cache up
+      id: rust-cache
+      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+      with:
+        # The cache key needs to be customised because we run in multiple matrix
+        # jobs and the caches were ending up with the same key. The OS and
+        # target vary between jobs, so make it unique again.
         key: ${{ runner.os }}-${{ inputs.target }}
 
     - name: Install cross toolchain
+      id: cross
       if:
-        inputs.target == 'aarch64-unknown-linux-gnu' &&
-        steps.cache.outputs.cache-hit != 'true'
+        inputs.target == 'aarch64-unknown-linux-gnu' && (
+        steps.restore-cache.outputs.cache-hit != 'true' ||
+        steps.rust-cache.outputs.cache-hit != 'true' )
       shell: sh
       run: |
         # Set up apt sources for arm64
@@ -88,7 +90,8 @@ runs:
         EOF
 
     - name: Build
-      if: steps.cache.outputs.cache-hit != 'true'
+      id: build
+      if: steps.cross.conclusion == 'success'
       shell: sh
       env:
         PKG_CONFIG_SYSROOT_DIR: ${{ inputs.pkg-config-sysroot }}
@@ -97,3 +100,15 @@ runs:
           --target ${{ inputs.target }} \
           ${{ inputs.build-type == 'release' && '--release' || ''}} \
           ${{ inputs.target-dir && format('--target-dir {}', inputs.target-dir) || ''}}
+
+    - name: Save cache
+      id: save-cache
+      if: steps.build.conclusion == 'success'
+      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: |
+          target/release/**
+          target/*/release/**
+        key: >
+          build-cargo-${{ runner.os }}-${{ inputs.target }}-${{
+          inputs.build-type }}-${{ hashFiles('**/Cargo.lock','**/*.rs') }}

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
+          always-restore-build-cache: true
           build-type:
             ${{ github.event_name == 'pull_request' && 'debug' || 'release' }}
           pkg-config-sysroot: ${{ matrix.config.sysroot }}


### PR DESCRIPTION
The `Swatinem/rust-cache` action cleans the workspace before saving the cache. That's fine for building, but we also want to cache the built binaries between jobs too. For two reasons:

1. To avoid building it on subsequent pushes when the source files haven't changed.
2. We build once in either the `build` or `oidc` workflows (whichever comes first) and then use the same binary in the other workflow.

For either of these the actual binaries themselves need to be restored. Switch to using `actions/cache/restore` and `actions/cache/save` directly, which allows us to control when the saving/restoring happens. We need to do this, because `Swatinem/rust-cache` will run its `post` step to save the cache _before_ `actions/cache` would save its cache. And that erases our built artifacts, so when `actions/cache`'s `post` step gets to it, the files are gone.

Now then. We were actually caching the depdencies twice before, once using `actions/cache` and once via `actions-rust-lang/setup-rust-toolchain`'s usage of `Swatinem/rust-cache`. That's fixed here to keep two caches: our binaries, and the Rust dependencies. There's no point in restoring the binaries if there's a non-exact match, since we will rebuild anyway, so drop `restore-keys`.

But then we discover that this hid a bug. We we want to skip rebuilding in the cache of a cache hit - that's half the point of using the cache - but we _do_ want to run the tests anyway (now that I think about it: if nothing changed, why do we? don't want to think about that now...). So we let the `build` job ask for the cache to be restored.

One more thing. We should rebuild in the case the toolchain changes, not only our own source files. The `if` conditions are altered slightly so that the build runs if _either_ cache has a miss.
