### PR TITLE
Update Pulumi workflow name

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -16,8 +16,8 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             sysroot: /usr/lib/aarch64-linux-gnu
 
-    # Share build results via cache between the `build-rust.yml` and `oidc.yml`
-    # workflows, because they have the same concurrency group.
+    # Share build results via cache between the `build-rust.yml` and
+    # `pulumi.yml` workflows, because they have the same concurrency group.
     #
     # For pull requests, the concurrency group is based on the pull request's
     # SHA. For pushes, the concurrency group is based on the branch name. This

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-name: Authenticate with AWS
+name: Run Pulumi
 
 jobs:
   oidc_debug_test:
@@ -31,7 +31,7 @@ jobs:
           audience: "${{ github.server_url }}/${{ github.repository_owner }}"
 
   pulumi:
-    # Share build results via cache between the `build-rust.yml` and `oidc.yml`
+    # Share build results via cache between the `build-rust.yml` and `pulumi.yml`
     # workflows, because they have the same concurrency group.
     #
     # For pull requests, the concurrency group is based on the pull request's
@@ -47,7 +47,9 @@ jobs:
         github.ref }}-aarch64-unknown-linux-gnu
       cancel-in-progress: false
 
-    name: Pulumi
+    name: >-
+      Pulumi ${{ (github.event_name == 'push' && github.ref ==
+      'refs/heads/main') && 'up' || 'preview' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
It's annoying it was called `oidc` and the name was `Authenticate with AWS` when it was doing lots more than that.
