### PR TITLE
CI: Fix Actions concurrency with pushes

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -6,7 +6,30 @@ on:
 
   pull_request:
 
+concurrency:
+  # Make sure each push gets a separate concurrency group so pushes to main
+  # don't cancel each other.
+  group: >-
+    build-${{
+      github.event_name == 'pull_request' &&
+      github.ref ||
+      github.sha
+    }}
+  cancel-in-progress: true
+
 jobs:
+  # Actions only allows one waiter per concurrency group, so we do the waiting
+  # ourselves.
+  turnstile:
+    name: Wait for any other builds of ${{ github.workflow }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Wait
+        uses: softprops/turnstyle@a4aad77d10d0bc4fa51eb6beda0a63ed9741d7ca # v2.1.0
+        with:
+          continue-after-seconds: 600
+
   build:
     strategy:
       matrix:
@@ -17,19 +40,10 @@ jobs:
             sysroot: /usr/lib/aarch64-linux-gnu
 
     # Share build results via cache between the `build-rust.yml` and
-    # `pulumi.yml` workflows, because they have the same concurrency group.
-    #
-    # For pull requests, the concurrency group is based on the pull request's
-    # SHA. For pushes, the concurrency group is based on the branch name. This
-    # allows the workflows to run concurrently for different branches, but not
-    # for the same branch. When we run for pushes, we actually deploy the
-    # infrastructure, so we don't want jobs to run concurrently.
+    # `pulumi.yml` workflows, because they have the same concurrency group. The
+    # later one will wait for the earlier.
     concurrency:
-      group: >-
-        build-${{
-          github.event_name == 'pull_request' &&
-          github.sha ||
-        github.ref }}-${{ matrix.config.target }}
+      group: build-${{ github.sha }}-${{ matrix.config.target }}
       cancel-in-progress: false
 
     name: Build, test, format

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -7,7 +7,30 @@ on:
 
 name: Run Pulumi
 
+concurrency:
+  # Make sure each push gets a separate concurrency group so pushes to main
+  # don't cancel each other.
+  group: >-
+    pulumi-${{
+      github.event_name == 'pull_request' &&
+      github.ref ||
+      github.sha
+    }}
+  cancel-in-progress: true
+
 jobs:
+  # Actions only allows one waiter per concrrency group, so we do the waiting
+  # ourselves.
+  turnstile:
+    name: Wait for any other builds of ${{ github.workflow }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Wait
+        uses: softprops/turnstyle@a4aad77d10d0bc4fa51eb6beda0a63ed9741d7ca # v2.1.0
+        with:
+          continue-after-seconds: 600
+
   oidc_debug_test:
     name: Debug OIDC claims
 
@@ -31,20 +54,11 @@ jobs:
           audience: "${{ github.server_url }}/${{ github.repository_owner }}"
 
   pulumi:
-    # Share build results via cache between the `build-rust.yml` and `pulumi.yml`
-    # workflows, because they have the same concurrency group.
-    #
-    # For pull requests, the concurrency group is based on the pull request's
-    # SHA. For pushes, the concurrency group is based on the branch name. This
-    # allows the workflows to run concurrently for different branches, but not
-    # for the same branch. When we run for pushes, we actually deploy the
-    # infrastructure, so we don't want jobs to run concurrently.
+    # Share build results via cache between the `build-rust.yml` and
+    # `pulumi.yml` workflows, because they have the same concurrency group. The
+    # later one will wait for the earlier.
     concurrency:
-      group: >-
-        build-${{
-          github.event_name == 'pull_request' &&
-          github.sha ||
-        github.ref }}-aarch64-unknown-linux-gnu
+      group: build-${{ github.sha }}-aarch64-unknown-linux-gnu
       cancel-in-progress: false
 
     name: >-


### PR DESCRIPTION
We use the built artifacts for arm64 in two jobs. To save effort, we have set up a concurrency group so that the build happens once and the second fetches it from the cache.

This worked okay in PRs, but for pushes a problem emerged. The behaviour we want is that each push to `main` gets a deployment in turn, or alternatively gets to complete before the latest one starts. If there are multiple in a short space, what we're actually seeing is in-progress jobs being cancelled. This is because GitHub Actions only allows one queued job per concurrency group ever.

It happens like this:

- Push 1 starts, build job starts, deployment job queued
- Push 2 arrives and _cancels_ both the in-progress and queued jobs from push 1

Here's an attempt at solving this in two ways. First, we rework the concurrency groups. The build jobs (in two different workflows btw) will share a group as before with `cancel-in-progress: false`. Next we'll add a workflow-level concurrency groups so that PR builds cancel earlier ones (to not waste resources on building superseded commits) but pushes don't so that the below queue is used.

And finally we add [`turnstyle`][turnstyle] to both workflows. This is where the workaround for GitHub's limitation comes in. It will ensure that only one job runs at a time per-branch for the workflow it's running in, by waiting in a loop (up to a 10 minute timeout) until it's the only one runningv

[turnstyle]: https://github.com/marketplace/actions/action-turnstyle
