### PR TITLE
build: Remove pinning of opentelemetry_aws

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,8 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-aws"
-version = "0.10.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust-contrib.git?rev=b62a0ff750d0890a7f75e61629d4f4d153ce1dee#b62a0ff750d0890a7f75e61629d4f4d153ce1dee"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cee12755d505c57e632de10bf1446be9d964492fca72954cb25f02e5061740"
 dependencies = [
  "once_cell",
  "opentelemetry",

--- a/lambda-rssfilter/Cargo.toml
+++ b/lambda-rssfilter/Cargo.toml
@@ -12,7 +12,7 @@ lambda_runtime = "0.12.0"
 log = "0.4.22"
 once_cell = "1.19.0"
 opentelemetry = "0.23.0"
-opentelemetry-aws = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib.git", rev = "b62a0ff750d0890a7f75e61629d4f4d153ce1dee" }
+opentelemetry-aws = { version = "0.11.0" }
 opentelemetry-otlp = { version = "0.16.0" }
 opentelemetry-semantic-conventions = "0.15.0"
 opentelemetry-stdout = "0.4.0"


### PR DESCRIPTION
We needed a particular commit but that's in a release now.
