### PR TITLE
build: Enable fat LTO for release builds

### DIFF
--- a/lambda-rssfilter/Cargo.toml
+++ b/lambda-rssfilter/Cargo.toml
@@ -3,6 +3,9 @@ name = "lambda-rssfilter"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+lto = true
+
 [dependencies]
 aws_lambda_events = "0.15.1"
 filter-rss-feed = { path = "../filter-rss-feed" }


### PR DESCRIPTION
Might improve performance a bit, and we aren't particularly worried about release builds taking a bit longer.
