### PR TITLE
pulumi/pnpm fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,11 +22,6 @@
       "source": "${localWorkspaceFolderBasename}-cache",
       "target": "/home/rust/.cache",
       "type": "volume"
-    },
-    {
-      "source": "${localWorkspaceFolderBasename}-node-modules",
-      "target": "${containerWorkspaceFolder}/pulumi/node_modules",
-      "type": "volume"
     }
   ],
 
@@ -50,7 +45,8 @@
         "rust-lang.rust-analyzer",
         "esbenp.prettier-vscode",
         "github.vscode-github-actions",
-        "me-dutour-mathieu.vscode-github-actions"
+        "me-dutour-mathieu.vscode-github-actions",
+        "Swellaby.vscode-rust-test-adapter"
       ]
     }
   }

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-for dir in ~/.cargo ~/.pulumi ~/.cache pulumi/node_modules; do
+for dir in ~/.cargo ~/.pulumi ~/.cache; do
     sudo chown "${USER}:${USER}" "$dir"
 done
 

--- a/pulumi/.npmrc
+++ b/pulumi/.npmrc
@@ -1,1 +1,0 @@
-include-worskpace-root = true

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -14,7 +14,7 @@
     "@types/archiver": "^6.0.2",
     "@types/folder-hash": "^4.0.4",
     "@types/node": "^20.14.11",
-    "@types/readable-stream": "^4",
+    "@types/readable-stream": "^4.0.15",
     "@typescript-eslint/parser": "^7.16.1",
     "eslint": "^9.7.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pulumi/pnpm-lock.yaml
+++ b/pulumi/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: ^20.14.11
         version: 20.14.11
       '@types/readable-stream':
-        specifier: ^4
+        specifier: ^4.0.15
         version: 4.0.15
       '@typescript-eslint/parser':
         specifier: ^7.16.1
@@ -689,8 +689,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001642:
-    resolution: {integrity: sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==}
+  caniuse-lite@1.0.30001643:
+    resolution: {integrity: sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -953,10 +953,10 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
-  fdir@6.1.1:
-    resolution: {integrity: sha512-QfKBVg453Dyn3mr0Q0O+Tkr1r79lOTAKSi9f/Ot4+qVEwxWhav2Z+SudrG9vQjM2aYRMQQZ2/Q1zdA8ACM1pDg==}
+  fdir@6.2.0:
+    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
     peerDependencies:
-      picomatch: 3.x
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1401,8 +1401,8 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
 
-  node-releases@2.0.17:
-    resolution: {integrity: sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==}
+  node-releases@2.0.18:
+    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -2404,7 +2404,7 @@ snapshots:
       '@types/semver': 7.5.8
       '@types/tmp': 0.2.6
       execa: 5.1.1
-      fdir: 6.1.1(picomatch@3.0.1)
+      fdir: 6.2.0(picomatch@3.0.1)
       google-protobuf: 3.21.4
       got: 11.8.6
       ini: 2.0.0
@@ -2733,9 +2733,9 @@ snapshots:
 
   browserslist@4.23.2:
     dependencies:
-      caniuse-lite: 1.0.30001642
+      caniuse-lite: 1.0.30001643
       electron-to-chromium: 1.4.832
-      node-releases: 2.0.17
+      node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
   buffer-crc32@1.0.0: {}
@@ -2780,7 +2780,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001642: {}
+  caniuse-lite@1.0.30001643: {}
 
   chalk@2.4.2:
     dependencies:
@@ -3056,7 +3056,7 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fdir@6.1.1(picomatch@3.0.1):
+  fdir@6.2.0(picomatch@3.0.1):
     optionalDependencies:
       picomatch: 3.0.1
 
@@ -3473,7 +3473,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  node-releases@2.0.17: {}
+  node-releases@2.0.18: {}
 
   nopt@7.2.1:
     dependencies:

--- a/pulumi/src/build-rust-lambda.ts
+++ b/pulumi/src/build-rust-lambda.ts
@@ -1,7 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import archiver from "archiver";
 import { buffer } from "stream/consumers";
-import { hashElement } from "folder-hash";
 import type {
   HashElementNode as DirectoryHash,
   HashElementOptions,
@@ -140,6 +139,8 @@ class BuildRustProvider implements pulumi.dynamic.ResourceProvider {
   private async hashDirectory(
     base: string,
   ): Promise<BuildRustProviderOutputs["directoryHash"]> {
+    const { hashElement } = await import("folder-hash");
+
     const options: HashElementOptions = {
       algo: "sha256",
       encoding: "base64",


### PR DESCRIPTION
I just had an annoying problem where `pulumi up` wouldn't work because it couldn't find a module from our dynamic resource provider. It turns out - after _much_ poking - that the old version of the code is stored in the state, and one of the `import`s in that one couldn't be resolved any more.
Hopefully fix that by making the import dynamic.

And refresh the lock file and fix one or two dep specifiers.

(And a bonus extension addition)
