### PR TITLE
chore(renovate): update renovate itself less frequently, group tracing & otel together

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -6,18 +6,18 @@
       "customType": "regex",
       "fileMatch": [
         "(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$",
-        "(^|/)action\\.ya?ml$"
+        "(^|/)action\\.ya?ml$",
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_-]+?[_-](?:VERSION|version)\\s*:\\s*[\"']?(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?"
-      ]
-    }
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_-]+?[_-](?:VERSION|version)\\s*:\\s*[\"']?(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
+      ],
+    },
   ],
   "forkProcessing": "enabled",
   "globalExtends": ["config:best-practices"],
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": true,
   },
   "onboarding": false,
   "osvVulnerabilityAlerts": true,
@@ -25,32 +25,38 @@
     {
       "groupName": "opentelemetry",
       "matchPackageNames": "opentelemetry*",
-      "matchManagers": ["cargo"]
+      "matchManagers": ["cargo"],
     },
     {
       "labels": ["update-major"],
-      "matchUpdateTypes": ["major"]
+      "matchUpdateTypes": ["major"],
     },
     {
       "labels": ["automerge", "update-minor"],
       "matchUpdateTypes": ["minor"],
-      "automerge": true
+      "automerge": true,
     },
     {
       "labels": ["automerge", "update-patch"],
       "matchUpdateTypes": ["patch"],
-      "automerge": true
+      "automerge": true,
     },
     {
       "labels": ["update-digest"],
-      "matchUpdateTypes": ["digest"]
-    }
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+    },
+    {
+      // Run the custom matcher on early Monday mornings (UTC)
+      "schedule": "* 0-4 * * 1",
+      "matchPackageNames": ["ghcr.io/renovatebot/renovate"],
+    },
   ],
   "platformCommit": "enabled",
   "rebaseWhen": "behind-base-branch",
   "requireConfig": "optional",
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["automerge-security-update"]
-  }
+    "labels": ["automerge-security-update"],
+  },
 }

--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -23,8 +23,8 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "groupName": "opentelemetry",
-      "matchPackageNames": "opentelemetry*",
+      "groupName": "tracing",
+      "matchPackageNames": ["tracing*", "opentelemetry*"],
       "matchManagers": ["cargo"],
     },
     {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,14 +6,14 @@ on:
 
   pull_request:
     paths:
-      - .github/renovate-config.json
+      - .github/renovate-config.json5
       - .github/workflows/renovate.yml
 
   push:
     branches:
       - main
     paths:
-      - .github/renovate-config.json
+      - .github/renovate-config.json5
       - .github/workflows/renovate.yml
 
   workflow_dispatch:
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          sparse-checkout: .github/renovate-config.json
+          sparse-checkout: .github/renovate-config.json5
 
       - name: Generate token
         id: generate-token
@@ -47,7 +47,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@e3a862510f27d57a380efb11f0b52ad7e8dbf213 # v41.0.6
         with:
-          configurationFile: .github/renovate-config.json
+          configurationFile: .github/renovate-config.json5
           # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
           renovate-version: 39.72.4@sha256:ddcaec18fe9aaaddbac331842e498febf3c4cf1543113bca8ffb4bea0f29c8d9
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
A couple of bundled fixes to Renovate's config - see individual commits for details.
