### PR TITLE
chore(renovate): pin dependencies

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -14,7 +14,7 @@
     },
   ],
   "forkProcessing": "enabled",
-  "globalExtends": ["config:best-practices"],
+  "globalExtends": [":pinDependencies", "config:best-practices"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "blueglassblock.better-json5",
     "dbaeumer.vscode-eslint",
     "swellaby.vscode-rust-test-adapter"
   ]

--- a/pulumi/core/package.json
+++ b/pulumi/core/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "@pulumi/aws-native": "^1.0.2",
-    "@pulumi/pulumi": "^3.136.1"
+    "@pulumi/pulumi": "^3.143.0"
   }
 }

--- a/pulumi/pnpm-lock.yaml
+++ b/pulumi/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         specifier: ^1.0.2
         version: 1.16.0(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))(typescript@5.7.2)
       '@pulumi/pulumi':
-        specifier: ^3.136.1
+        specifier: ^3.143.0
         version: 3.143.0(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))(typescript@5.7.2)
     devDependencies:
       '@types/node':


### PR DESCRIPTION
This is recommended by renovate upstream.

Also, install the `json5` extension in vscode to have some support for this filetype in the devcontainer.
