### PR TITLE
Revert "feat(renovate): create a dependency dashboard"

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -13,7 +13,6 @@
       ],
     },
   ],
-  "dependencyDashboard": true,
   "forkProcessing": "enabled",
   "globalExtends": [":pinDependencies", "config:best-practices"],
   "lockFileMaintenance": {


### PR DESCRIPTION
It's creating a new issue each time Renovate runs and I can't be bothered to debug that right now - the dashboard isn't super useful anyway.

Reverts iainlane/rssfilter#770