### PR TITLE
fix(renovate): remove RENOVATE_USERNAME

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -67,4 +67,3 @@ jobs:
             'full' || null }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_USERNAME: laneybot


### PR DESCRIPTION
This should have been set to `laneybot[bot]` to work properly. But it turns out it's not actually needed at all, since Renovate can find it itself. So it'll be better to just drop it altogether.
