### PR TITLE
chore(pulumi): namespace the storage bucket by stack, add lifecycle rules

### DIFF
--- a/pulumi/src/build-upload.ts
+++ b/pulumi/src/build-upload.ts
@@ -32,6 +32,17 @@ export const storageBucket = new aws.s3.Bucket("lambda-rssfilter", {
     ignorePublicAcls: true,
     restrictPublicBuckets: true,
   },
+  lifecycleConfiguration: {
+    rules: [
+      {
+        status: "Enabled",
+        noncurrentVersionExpiration: {
+          noncurrentDays: 7,
+          newerNoncurrentVersions: 5,
+        },
+      },
+    ],
+  },
   versioningConfiguration: {
     status: aws.s3.BucketVersioningConfigurationStatus.Enabled,
   },


### PR DESCRIPTION
I noticed this was getting a bit large, because we never prune old versions. We're adding a lifecycle configuration to keep 5 versions older than 7 days, so previous ones are pruned out.
