### PR TITLE
fix: use inline format arguments in format strings

### DIFF
--- a/filter-rss-feed/src/header_cf_cache_status.rs
+++ b/filter-rss-feed/src/header_cf_cache_status.rs
@@ -33,7 +33,7 @@ impl fmt::Display for CfCacheStatus {
             CfCacheStatus::Revalidated => write!(f, "REVALIDATED"),
             CfCacheStatus::Updating => write!(f, "UPDATING"),
             CfCacheStatus::Bypass => write!(f, "BYPASS"),
-            CfCacheStatus::Other(s) => write!(f, "{}", s),
+            CfCacheStatus::Other(s) => write!(f, "{s}"),
         }
     }
 }
@@ -175,7 +175,7 @@ mod tests {
     #[test_case(CfCacheStatus::Bypass, "BYPASS"; "bypass displays as uppercase")]
     #[test_case(CfCacheStatus::Other("custom".to_string()), "custom"; "other displays original")]
     fn test_display(status: CfCacheStatus, expected: &str) {
-        assert_eq!(format!("{}", status), expected);
+        assert_eq!(format!("{status}"), expected);
     }
 
     #[test]

--- a/filter-rss-feed/src/lib.rs
+++ b/filter-rss-feed/src/lib.rs
@@ -124,8 +124,7 @@ impl<'a> RssFilter<'a> {
 
         let request = request_builder.body(Bytes::new()).map_err(|e| {
             RssError::HttpClient(HttpClientError::Request(format!(
-                "Failed to build request: {}",
-                e
+                "Failed to build request: {e}"
             )))
         })?;
 

--- a/rssfilter-cli/src/rssfilter.rs
+++ b/rssfilter-cli/src/rssfilter.rs
@@ -64,7 +64,7 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let filtered = rss_filter.fetch_and_filter(&opt.url).await?.into_body();
 
     let s = std::str::from_utf8(&filtered)?;
-    println!("{}", s);
+    println!("{s}");
 
     Ok(())
 }

--- a/rssfilter-telemetry/src/formatting.rs
+++ b/rssfilter-telemetry/src/formatting.rs
@@ -25,8 +25,7 @@ impl FromStr for LogFormat {
             "pretty" => Ok(LogFormat::Pretty),
             "json" => Ok(LogFormat::Json),
             _ => Err(format!(
-                "Invalid log format: '{}'. Valid options are 'pretty' or 'json'",
-                s
+                "Invalid log format: '{s}'. Valid options are 'pretty' or 'json'"
             )),
         }
     }
@@ -40,7 +39,7 @@ pub enum TracingError {
 impl fmt::Display for TracingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TracingError::OtlpError(msg) => write!(f, "OTLP error: {}", msg),
+            TracingError::OtlpError(msg) => write!(f, "OTLP error: {msg}"),
         }
     }
 }

--- a/rssfilter-telemetry/src/native.rs
+++ b/rssfilter-telemetry/src/native.rs
@@ -45,9 +45,7 @@ impl LogConfig {
             .with_http()
             .with_endpoint(otlp_endpoint)
             .build()
-            .map_err(|e| {
-                TracingError::OtlpError(format!("Failed to create OTLP exporter: {}", e))
-            })?;
+            .map_err(|e| TracingError::OtlpError(format!("Failed to create OTLP exporter: {e}")))?;
 
         let service_name =
             env::var("SERVICE_NAME").unwrap_or_else(|_| "cloudflare-worker".to_string());

--- a/workers-rssfilter/src/lib.rs
+++ b/workers-rssfilter/src/lib.rs
@@ -895,8 +895,7 @@ mod wasm_tests {
         );
         assert!(
             is_expected_error,
-            "Expected a parameter-related or content error, got: {:?}",
-            rss_error
+            "Expected a parameter-related or content error, got: {rss_error:?}"
         );
 
         let response: Response<Bytes> = rss_error.into();
@@ -1087,7 +1086,7 @@ mod request_validation_integration_tests {
     async fn test_validate_request_various_wrong_paths(path: &str) {
         let req = Request::builder()
             .method(Method::GET)
-            .uri(format!("https://test.example.com{}", path))
+            .uri(format!("https://test.example.com{path}"))
             .body(Body::empty())
             .unwrap();
 
@@ -1095,8 +1094,7 @@ mod request_validation_integration_tests {
         assert_eq!(
             response.status().as_u16(),
             *NOT_FOUND,
-            "Expected 404 for path: {}",
-            path
+            "Expected 404 for path: {path}"
         );
     }
 
@@ -1197,7 +1195,7 @@ mod error_conversion_tests {
         assert_eq!(config.rust_log, cloned.rust_log);
 
         // Verify Debug trait works
-        let debug_str = format!("{:?}", config);
+        let debug_str = format!("{config:?}");
         assert!(debug_str.contains("json"));
         assert!(debug_str.contains("debug"));
     }


### PR DESCRIPTION
Apply clippy suggestions to use variables directly in format strings instead of passing them as separate arguments. This improves readability and follows Rust best practices for string formatting.