### PR TITLE
chore: gitignore .wrangler/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .devcontainer/.env
 .pnpm-store/
+.wrangler/
 /target
 node_modules


### PR DESCRIPTION
This directory contains working files for the `wrangler` CLI which we use for our workers deployment. It shouldn't be included.
