### PR TITLE
chore: specify exact node version in package.json

### DIFF
--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -2,7 +2,7 @@
   "name": "lambda-rssfilter",
   "main": "src/index.ts",
   "engines": {
-    "node": "23"
+    "node": "22.16.0"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
This ensures that CI and developers are always using the same version, if they use something like fnm/nvm/volta.
