### PR TITLE
ci: remove magic-nix-cache-action to unblock PR builds

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -61,12 +61,6 @@ jobs:
         with:
           determinate: false
 
-      - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-        with:
-          use-flakehub: disabled
-          use-gha-cache: enabled
-
       - name: Run checks
         env:
           CHECK_TARGETS: ${{ matrix.config.check-targets }}


### PR DESCRIPTION
## Summary

Every open renovate PR has been failing on the `aarch64-linux` Test Suite job for the past few days, which then cancels `x86_64-linux` and `wasm` via matrix fail-fast. Same workflow on `push` to `main` keeps passing.

The pattern (PR runs fail in ~5min, main pushes succeed; same workflow file unchanged since March) points at `DeterminateSystems/magic-nix-cache-action@v13`. The action was sunset in Feb 2025 and resurrected as a best-effort reverse-engineering of the GHA Cache v2 API, with open reports of post-step hangs/405s. Combined with `concurrency.cancel-in-progress: true` on non-main refs (so previous PR runs SIGTERM the cache daemon mid-upload), this matches the symptom; main isn't subject to cancel-in-progress and shuts down cleanly.

Drop the cache step. Builds will be slower but reliable. We can revisit with `actions/cache` against `/nix/store` or FlakeHub Cache when we want speed back.

## Test plan

- [ ] CI on this PR turns green on all three matrix jobs (`x86_64-linux`, `aarch64-linux`, `wasm`)
- [ ] Rebase one of the stuck renovate PRs (e.g. #1860) on top of this and confirm it goes green too

https://claude.ai/code/session_018yAtrb6YbDXW6JuznZCt1y

---
_Generated by [Claude Code](https://claude.ai/code/session_018yAtrb6YbDXW6JuznZCt1y)_