### PR TITLE
fix(deps): replace stale git-pinned otel deps that blocked all merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry-resource-detectors"
 version = "0.11.0"
-source = "git+https://github.com/cijothomas/opentelemetry-rust-contrib?rev=91d5d87c9acefcfc8dd7816054283b8ec0ea1402#91d5d87c9acefcfc8dd7816054283b8ec0ea1402"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8b28af3391a756b248f470f59b35041dd3ac9b9633d2df40757df709314f1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -2494,11 +2495,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
-source = "git+https://github.com/houseme/tracing-opentelemetry?rev=66acd7b5abd279eed1699706c35c16365c3f64ec#66acd7b5abd279eed1699706c35c16365c3f64ec"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "lazy_static",
  "opentelemetry",
  "smallvec",
  "tracing",

--- a/rssfilter-telemetry/Cargo.toml
+++ b/rssfilter-telemetry/Cargo.toml
@@ -10,13 +10,13 @@ opentelemetry-semantic-conventions = "=0.32.0"
 opentelemetry-stdout = "=0.32.0"
 thiserror = "=2.0.18"
 tracing = "=0.1.44"
-tracing-opentelemetry = { git = "https://github.com/houseme/tracing-opentelemetry", rev = "66acd7b5abd279eed1699706c35c16365c3f64ec", features = ["lazy_static"] }
+tracing-opentelemetry = "=0.33.0"
 tracing-subscriber = { version = "=0.3.23", features = [
   "ansi",
   "env-filter",
   "json",
 ] }
-opentelemetry-resource-detectors = { git = "https://github.com/cijothomas/opentelemetry-rust-contrib", rev = "91d5d87c9acefcfc8dd7816054283b8ec0ea1402" }
+opentelemetry-resource-detectors = "=0.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 opentelemetry-otlp = { version = "=0.32.0", features = ["http-proto"] }

--- a/workers-rssfilter/Cargo.toml
+++ b/workers-rssfilter/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "=0.13.3", default-features = false, features = ["json"] }
 thiserror = "=2.0.18"
 tower = "=0.5.3"
 tracing = "=0.1.44"
-tracing-opentelemetry = { git = "https://github.com/houseme/tracing-opentelemetry", rev = "66acd7b5abd279eed1699706c35c16365c3f64ec", features = ["lazy_static"] }
+tracing-opentelemetry = "=0.33.0"
 url = "=2.5.8"
 urlencoding = "=2.1.3"
 web-time = "=1.1.0"


### PR DESCRIPTION
## What was blocking merges

Every open PR fails the `x86_64-linux` check in ~34s, which cancels the `aarch64-linux` and `wasm` jobs (fail-fast matrix). The failure is a **Nix evaluation error**, before any build runs:

```
error: Cannot find Git revision '91d5d87c9acefcfc8dd7816054283b8ec0ea1402'
in ref 'refs/heads/main' of repository 'https://github.com/cijothomas/opentelemetry-rust-contrib'!
... or add allRefs = true; to fetchGit.
```

Two dependencies were pinned to git revisions on forks:

- `tracing-opentelemetry` → `houseme/tracing-opentelemetry` @ `66acd7b5`
- `opentelemetry-resource-detectors` → `cijothomas/opentelemetry-rust-contrib` @ `91d5d87c`

Both forks moved their default branches forward (a fork hard-resetting `main`/`v0.1.x` orphans old commits), so those revs are **no longer reachable from the default branch**. Crane vendors git deps with `builtins.fetchGit`, which only resolves revs on the default branch, so evaluation aborts. `cargo` still works because it fetches the SHA directly — which is why this isn't visible in local `cargo` builds, only in the Nix-based CI.

This affected **main and every open PR**. Renovate already had separate PRs to bump each (#1871, #1883), but neither could merge: each still contained the *other* stale rev, so the build stayed broken. A deadlock.

## The fix

Rather than just chase the moving fork revs, this removes the git pins entirely — both crates now have suitable releases on crates.io:

| dep | before | after |
|-----|--------|-------|
| `opentelemetry-resource-detectors` | git `cijothomas@91d5d87c` | crates.io `=0.11.0` (same version the pin resolved to; deps on otel `^0.32`) |
| `tracing-opentelemetry` | git `houseme@66acd7b5`, `features = ["lazy_static"]` | crates.io `=0.33.0` (first official release targeting otel 0.32) |

Notes:
- `lazy_static` was an *optional dependency* the fork declared but never referenced in code, so dropping the feature is a no-op.
- The fork was pinned to `houseme`'s `v0.1.x` (not its `fix/deadlock-fix` branch), i.e. it was tracking a branch for early otel-0.32 support, which official `0.33.0` now provides.

**No git-pinned dependencies remain**, which removes this entire class of breakage (a fork moving its default branch can no longer break `nix build` evaluation).

Once this lands on `main`, rebasing the other open PRs onto it clears the deadlock for all of them.

## Test plan

- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo test --workspace --locked` — 120 passed, 0 failed
- [x] Reproduced the original failure locally via Nix, then confirmed the **full CI check set** passes on the final state: `nix build .#checks.x86_64-linux.{build,tests,clippy,doc,treefmt,statix,markdownlint}` — all green
- [ ] CI green on this PR

https://claude.ai/code/session_019C9CqbMNG1GPmxbgQiutQg

---
_Generated by [Claude Code](https://claude.ai/code/session_019C9CqbMNG1GPmxbgQiutQg)_