### PR TITLE
fix(deps): update uuid to 1.23.1 (unstick #1752)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,9 +2615,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/workers-rssfilter/Cargo.toml
+++ b/workers-rssfilter/Cargo.toml
@@ -36,7 +36,7 @@ web-time = "=1.1.0"
 worker = { version = "=0.8.3", features = ["http"] }
 worker-macros = { version = "=0.8.3", features = ["http"] }
 opentelemetry-http = "=0.32.0"
-uuid = { version = "=1.21.0", features = ["rng-getrandom", "v4"] }
+uuid = { version = "=1.23.1", features = ["rng-getrandom", "v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { package = "getrandom", version = "=0.4.2", features = [


### PR DESCRIPTION
## Summary

Re-applies the legitimate part of the stuck Renovate PR #1752 on top of current `main`. Bumps `uuid` 1.21.0 → 1.23.1 and **drops the broken `getrandom_0_3` bump**.

## Why #1752 was stuck

- **Merge conflict** — the PR is ~2.5 months old and `Cargo.lock` diverged from `main` (`mergeable_state: dirty`).
- **CI failing** — the `getrandom_0_3` change is invalid.
- **Renovate stopped auto-rebasing** — it no longer recognized the last commit author.

## Root cause of the build failure

`getrandom_0_3` is an intentional alias that pins `getrandom` to the **0.3.x** line. It exists to enable the `wasm_js` feature on the getrandom 0.3 that `rand_core` still pulls in transitively:

```
opentelemetry_sdk 0.32 → rand 0.9.4 → rand_core 0.9.5 → getrandom 0.3.4
```

Renovate's `uuid and getrandom` group rule treated this alias as a normal `getrandom` dependency and tried to bump it to `=0.4.2`. But the direct `getrandom` dependency is *already* `=0.4.2`, so two aliases end up resolving to the same crate version, which Cargo rejects:

```
error: the crate `workers-rssfilter` depends on crate `getrandom v0.4.2`
multiple times with different names
```

(Reproduced locally.) The alias must stay on 0.3.x until `rand`/`rand_core` move to getrandom 0.4.

## What this PR does

- `uuid` 1.21.0 → 1.23.1 in `workers-rssfilter/Cargo.toml` + `Cargo.lock`.
- Leaves `getrandom_0_3` at `=0.3.4`.

## Verification

- `cargo check --workspace` (native) ✅
- `cargo check -p workers-rssfilter --target wasm32-unknown-unknown` ✅

## Follow-up suggestion (not included here)

The PR #1752 is marked **Immortal**, so Renovate will likely re-propose the broken `getrandom_0_3 → 0.4` bump again. To prevent recurrence, consider adding a Renovate `packageRule`:

```json5
{
  // getrandom_0_3 intentionally pins getrandom to the 0.3.x line for the
  // wasm_js feature on the getrandom 0.3 that rand_core still requires.
  matchDepNames: ["getrandom_0_3"],
  allowedVersions: "<0.4",
}
```

Once this merges, #1752 can be closed.

https://claude.ai/code/session_01Kncv27c7Sw3ctuiQexRjze

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kncv27c7Sw3ctuiQexRjze)_