### PR TITLE
ci: scope laneybot token to app grants and use client-id

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,9 +18,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.LANEYBOT_APP_ID }}
+          client-id: ${{ secrets.LANEYBOT_APP_ID }}
           private-key: ${{ secrets.LANEYBOT_PRIVATE_KEY }}
-          # Scoped to what approving and enabling auto-merge on the PR needs.
           permission-contents: write
           permission-pull-requests: write
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,16 +48,13 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.LANEYBOT_APP_ID }}
+          client-id: ${{ secrets.LANEYBOT_APP_ID }}
           private-key: ${{ secrets.LANEYBOT_PRIVATE_KEY }}
-          # Scoped to what Renovate actually uses here: write code/PRs/the
-          # dependency-dashboard issue/pinned action SHAs, and read check
-          # results for automerge. Vulnerability alerts come from OSV
-          # (osvVulnerabilityAlerts), so no GitHub alerts permission is needed.
-          permission-checks: read
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: Self-hosted Renovate

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /target
 node_modules
 result
+result-*


### PR DESCRIPTION
## Summary

Follow-up to the flake-update PR (#1888). That PR scoped the LaneyBot app tokens to satisfy the newer zizmor (`github-app` audit), but the renovate token requested permissions the installation doesn't grant, so `create-github-app-token` returned `422 The permissions requested are not granted to this installation` (the `renovate` job failed at the token step in ~4s).

This requests exactly the permissions the LaneyBot installation grants:

- **renovate.yml**: `contents`, `issues`, `pull-requests`, `statuses`, `workflows` write; `vulnerability-alerts` read.
- **dependabot-auto-merge.yml**: `contents`, `pull-requests` write (approve + enable auto-merge).

Also:
- Switches `app-id` → `client-id` (the deprecated input). GitHub accepts the numeric App ID as the JWT issuer, so the existing `LANEYBOT_APP_ID` secret is reused unchanged.
- `.gitignore`: ignore numbered nix build result symlinks (`result-*`).

The Renovate workflow runs on this PR (it touches `renovate.yml`) in dry-run, so the `renovate` check live-validates that the scoped token now mints successfully.

## Test plan

- [ ] `renovate` check passes (token generated, dry-run completes)
- [ ] treefmt/zizmor passes (verified locally)
- [ ] build matrix passes

https://claude.ai/code/session_018TfZEeUD91P93qgVrFX6bi

---
_Generated by [Claude Code](https://claude.ai/code/session_018TfZEeUD91P93qgVrFX6bi)_