### PR TITLE
ci(renovate): stop the broken getrandom_0_3 auto-bump recurring

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -54,6 +54,19 @@
       matchPackageNames: ["uuid", "getrandom"],
       matchManagers: ["cargo"],
     },
+    {
+      // getrandom_0_3 is an intentional alias that pins getrandom to the 0.3.x
+      // line. It exists solely to enable the `wasm_js` feature on the
+      // getrandom 0.3 that opentelemetry_sdk (via rand 0.9 -> rand_core) still
+      // pulls in. The direct `getrandom` dependency is already on 0.4, so
+      // bumping this alias to 0.4 makes two aliases resolve to the same crate
+      // version, which cargo rejects. Constrain it to the 0.3 series; once
+      // opentelemetry_sdk moves to rand 0.10 (which uses getrandom 0.4) this
+      // alias and rule can be removed entirely.
+      matchDepNames: ["getrandom_0_3"],
+      matchManagers: ["cargo"],
+      allowedVersions: "<0.4",
+    },
 
     {
       labels: ["update-major"],


### PR DESCRIPTION
## Summary

Adds a Renovate `packageRule` that constrains the `getrandom_0_3` Cargo alias to the **0.3.x** series, stopping the recurring broken auto-update that made #1752 an immortal, perpetually-failing PR.

## Why

`getrandom_0_3` is an intentional alias pinning getrandom to 0.3.x. It exists solely to enable the `wasm_js` feature on the getrandom **0.3** that `opentelemetry_sdk` still drags in:

```
opentelemetry_sdk 0.32 → rand 0.9 → rand_core 0.9.5 → getrandom 0.3
```

The direct `getrandom` dependency is already on **0.4**. Renovate's existing `uuid and getrandom` group matches by **package name** (`getrandom`), so it kept sweeping the alias up and bumping it to `=0.4.2` — which makes two aliases resolve to the *same* crate version, something cargo rejects:

```
error: the crate `workers-rssfilter` depends on crate `getrandom v0.4.2`
multiple times with different names
```

This new rule matches by **dep name** (`getrandom_0_3`) and caps it at `<0.4`, so 0.3.x patch/minor updates still flow but the broken 0.4 jump is blocked.

## Upstream blocker (when this can be removed)

`rand 0.10` already uses getrandom 0.4, but `opentelemetry_sdk` requires `rand = "0.9"` — confirmed still true on opentelemetry-rust's `main` branch, not just the latest release, and no upstream issue tracks the move. Once opentelemetry_sdk adopts rand 0.10, both this rule **and** the `getrandom_0_3` alias can be deleted entirely.

## Validation

- JSON5 parses cleanly (`json5` parser).

https://claude.ai/code/session_01Kncv27c7Sw3ctuiQexRjze

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kncv27c7Sw3ctuiQexRjze)_