### PR TITLE
ci(wrangler): enable preview URLs for PR builds

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,6 +23,11 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
+  // Preview URLs are served only on `*.workers.dev`, and default to disabled
+  // when the workers.dev subdomain is off (as it is here, since we serve from
+  // custom domains). Enable them explicitly so Workers Builds publishes a
+  // preview URL for non-production branch builds and comments it on PRs.
+  "preview_urls": true,
   "routes": [
     {
       "pattern": "rssfilter.orangesquash.org.uk",


### PR DESCRIPTION
## Why

We weren't getting Cloudflare deployment previews on PRs. Deployment is already driven by Cloudflare Workers Builds (the Git integration builds on push — there's no `wrangler deploy` in GitHub Actions), and non-production branch builds are enabled. So Workers Builds *was* running `wrangler versions upload` for PR branches — but no preview URL was ever published.

The missing piece is the `preview_urls` setting. Per Cloudflare's docs:

> Preview URLs are enabled by default when `workers_dev` is enabled, and disabled by default when `workers_dev` is disabled.

This Worker is served only from custom domains (`rssfilter.orangesquash.org.uk` / `dev.rssfilter…`), with the `workers.dev` subdomain off, so `preview_urls` defaulted to **false**. A version uploaded per PR, but with no `*.workers.dev` URL to attach, nothing got commented.

## What

Set `preview_urls: true` explicitly in `wrangler.jsonc` so a preview URL is generated for non-production branch builds and Workers Builds comments it on the PR.

## Follow-up (dashboard, not in this repo)

Preview URLs can only be served on `*.workers.dev`. The Worker's **workers.dev subdomain must also be enabled** (Workers & Pages → rssfilter → Settings → Domains & Routes) for the preview URL to resolve. This PR alone won't be sufficient if that subdomain is disabled.

## Sources

- [Workers — Preview URLs](https://developers.cloudflare.com/workers/configuration/previews/)
- [Workers Builds — configuration](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/)
- [Workers Builds — GitHub integration](https://developers.cloudflare.com/workers/ci-cd/builds/git-integration/github-integration/)

https://claude.ai/code/session_0127DBnFhvLw1tFPoFfHFL1K

---
_Generated by [Claude Code](https://claude.ai/code/session_0127DBnFhvLw1tFPoFfHFL1K)_