### PR TITLE
feat(observability): enable Workers Traces

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,10 @@
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+    },
   },
   "routes": [
     {


### PR DESCRIPTION
Enables [Cloudflare Workers Traces](https://developers.cloudflare.com/workers/observability/traces/) by adding an `observability.traces` block to `wrangler.jsonc`:

```jsonc
"observability": {
  "enabled": true,
  "head_sampling_rate": 1,
  "traces": {
    "enabled": true,
    "head_sampling_rate": 1,
  },
},
```

The worker already had observability **logs** enabled, but Workers Traces is a separate, opt-in feature. It's currently in early beta, so it stays **off** even with an up-to-date `compatibility_date` unless explicitly enabled via `observability.traces.enabled`.

Workers Traces follows OpenTelemetry standards, which fits the existing `rssfilter-telemetry` OTel instrumentation. `head_sampling_rate` is set to `1` (100%) to match the existing logs sampling rate; it can be lowered later if volume becomes a concern.

No `compatibility_date` change is required to opt in during the beta, and `wrangler` 4.96.0 parses the updated config without errors.

https://claude.ai/code/session_014pLUZdRWsXB7jRrf7WCS1L