### PR TITLE
ci: let the dependency review actually post its comment

### DIFF
--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -44,11 +44,14 @@ jobs:
           # stripped, so "laneybot" matches laneybot[bot] (Renovate) and
           # "dependabot" matches dependabot[bot].
           allowed_bots: "laneybot,dependabot"
-          use_sticky_comment: true
+          # This runs in agent mode, so the action does not auto-post Claude's
+          # output — Claude must post it itself. Grant gh pr comment for that
+          # (gh is authenticated in the tool environment). use_sticky_comment
+          # has no effect in agent mode; stickiness is handled via gh below.
           claude_args: >-
             --model claude-sonnet-4-6 --max-turns 30 --allowedTools
             "Read,Glob,Grep,WebFetch,Bash(gh pr view:*),Bash(gh pr
-            diff:*),Bash(gh api:*)"
+            diff:*),Bash(gh api:*),Bash(gh pr comment:*)"
           prompt: |
             You are reviewing a dependency-update pull request in the
             iainlane/rssfilter repository: ${{ github.repository }} PR
@@ -94,10 +97,20 @@ jobs:
                install scripts, large size growth, publisher change,
                typosquatting) — a reason for caution.
 
-            Then post exactly ONE concise comment on the PR with your findings.
-            Keep it short and skip empty sections — for a routine patch/minor
-            bump with no codebase impact, a couple of lines is enough. Start the
-            comment with a single clear verdict line, one of:
+            Then you MUST post your findings as a comment on the PR — this is
+            the whole point of the job, and nothing posts it for you. Post
+            exactly one comment by running (gh is already authenticated):
+
+              gh pr comment ${{ github.event.pull_request.number }} \
+                --edit-last --create-if-none --body "<your markdown>"
+
+            Using `--edit-last --create-if-none` keeps it to a single comment
+            that updates in place when the PR is pushed to again, instead of
+            stacking a new comment each run.
+
+            Keep the comment short and skip empty sections — for a routine
+            patch/minor bump with no codebase impact, a couple of lines is
+            enough. Start it with a single clear verdict line, one of:
 
               - ✅ Safe to merge — no breaking changes affecting this repo.
               - ⚠️ Needs attention — <one-line reason>.


### PR DESCRIPTION
## Problem

The new `claude-dependency-review.yml` (from #1912) **ran but posted nothing** — e.g. on #1904 ([run](https://github.com/iainlane/rssfilter/actions/runs/26809450733/job/79035268824)).

The run log shows it worked right up to the last step:

```
Actor laneybot[bot] is in allowed_bots list, skipping human actor check
...
"subtype": "success", "num_turns": 10, "permission_denials_count": 1
```

In **agent mode**, `claude-code-action` does **not** auto-post the assistant's final message — the model has to post it via a tool. But the `allowedTools` list granted only *read* tools (`gh pr view`, `gh pr diff`, `gh api`). So Claude produced the review, tried to post it, and hit a **permission denial** (the `permission_denials_count: 1` above), and nothing reached the PR.

This matches how the reference dependency-review setups work — AutoGPT, `de-otio/.github`, `akr4/poc-dependabot-claude-code` all explicitly grant the agent a comment tool (`Bash(gh pr comment:*)`).

## Fix

- Add `Bash(gh pr comment:*)` to `allowedTools`.
- Add an explicit prompt instruction to post exactly one comment with
  `gh pr comment <n> --edit-last --create-if-none --body "…"`. `--edit-last --create-if-none` also makes the comment **sticky** — it updates in place on subsequent pushes instead of stacking new comments.
- Drop `use_sticky_comment: true`, which has no effect in agent mode (stickiness is now handled via `gh`).

## Verification note

This can't be fully verified until it runs on a real dependency PR (the next Renovate PR after merge). The change is config-only and mirrors known-good setups; the failure mode it fixes — a denied `gh pr comment` — is directly visible in the prior run's `permission_denials_count: 1`.

https://claude.ai/code/session_019QCt1Bze5EBQKxk6q6A83t

---
_Generated by [Claude Code](https://claude.ai/code/session_019QCt1Bze5EBQKxk6q6A83t)_