### PR TITLE
fix(deps): update all non-major dependencies (with lockfile fix)

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -1,6 +1,6 @@
 FROM ghcr.io/iainlane/dotfiles-rust-tools:git-24a7c0cfa3e9b909f954a85dd0b4163f6009f02d@sha256:8409474119d2b76e4064b049decdf4764dd2a280cfbcb77d289d65b878a9798c AS rust-tools
 
-FROM public.ecr.aws/aws-cli/aws-cli:2.34.63@sha256:c95ab0642137f55a12b95b6956dd03cefdbd73e760e0e7b870afc9b47f9c8150 AS aws-cli
+FROM public.ecr.aws/aws-cli/aws-cli:2.34.64@sha256:61beb8d127f3955415f866d647a0d9a3377497069e086af0594a6b1443970b5a AS aws-cli
 
 FROM pulumi/pulumi-base:3.245.0@sha256:c76f0c6fce1e78842ab99c0c048a8a51c3c3ebcf672895a7187ee2c94fa430aa AS pulumi
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1.0.141
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"

--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Dependency Review
         id: claude-dependency-review
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1.0.141
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The action refuses to run for non-human actors unless they are

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1.0.141
         with:
           additional_permissions: |
             actions: read

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -58,11 +58,11 @@ jobs:
           permission-workflows: write
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:
           configurationFile: .github/renovate-config.json5
           # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
-          renovate-version: 43.214.3@sha256:5dc5e19e1dbba656e0a8672d12e59305a992810da8d5460e5bc1706919193a74
+          renovate-version: 43.216.2@sha256:6407691343b8d4a8903cc87b0fc65a06c87c0e332447eb27f10fbbda6b726d6f
           token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,9 +843,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",

--- a/filter-rss-feed/Cargo.toml
+++ b/filter-rss-feed/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "=1.11.1"
 # Core dependencies used by both WASM and non-WASM
 env_logger = "=0.11.10"
 headers = "=0.4.1"
-http = "=1.4.1"
+http = "=1.4.2"
 log = "=0.4.32"
 regex = "=1.12.3"
 rss = "=2.0.13"
@@ -49,7 +49,7 @@ test-case = "=3.3.1"
 test-utils = { path = "../test-utils" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "=0.3.72"
+wasm-bindgen-test = "=0.3.73"
 
 # Non-WASM dev dependencies (test dependencies that don't work with WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/filter-rss-feed/Cargo.toml
+++ b/filter-rss-feed/Cargo.toml
@@ -49,7 +49,7 @@ test-case = "=3.3.1"
 test-utils = { path = "../test-utils" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "=0.3.73"
+wasm-bindgen-test = "=0.3.72"
 
 # Non-WASM dev dependencies (test dependencies that don't work with WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "devDependencies": {
-    "wrangler": "4.97.0"
+    "wrangler": "4.98.0"
   },
   "engines": {
     "node": "24.16.0"
   },
   "name": "workers-rssfilter",
-  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "private": true,
   "scripts": {
     "build": "wrangler deploy --dry-run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       wrangler:
-        specifier: 4.97.0
-        version: 4.97.0
+        specifier: 4.98.0
+        version: 4.98.0
 
 packages:
 
@@ -27,32 +27,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260601.1':
-    resolution: {integrity: sha512-iXZBVuRbvuVqQ/63wul01hHCv/3R8G5S8zbkjfoHvyPZFynmlKTV59Hk+H8whyGwFAZuB71UJGLr+G5mJKfjWA==}
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260601.1':
-    resolution: {integrity: sha512-veGpZQGBw07Twt+Y4z3oyo+/obKHt0iWUwvDV5GOiDAYjC/zW+YGstgVzg4SHq+k1sLH3ElqL2TXx20I5WBv3Q==}
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
+    resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260601.1':
-    resolution: {integrity: sha512-n/9hDz7fPGpYF0J684+Xr5zgjcS2jdmY2Of5m6e+eQ/M9+RfR+UaU8Ee/tkA1dDC0LYQB13hfPafZG66Ff1CsA==}
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    resolution: {integrity: sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260601.1':
-    resolution: {integrity: sha512-VHRZZbexATS+n+1j3x/CZaYbIJEye0J3iIHgG0Wp+l+NrZCKQ8qi8Lq1uTV0dLJQ67FuZtJtWdQ95mm9F7Fc+A==}
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260601.1':
-    resolution: {integrity: sha512-ye0C7MFLkeH16iTo8Tcjv2KiFmp23+sZGvUzSQa4xhP0QMe6EoJ+H/4SqqvnZ5nfN54slqKvx2VnXceENWe2CQ==}
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -427,8 +427,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  miniflare@4.20260601.0:
-    resolution: {integrity: sha512-56TFiulSEQu43cYxdXgCiA3U3i+Ls0NoXwJXd6DmpNsx8yl/1Il2T3DQ4CMXjR6yfE7CSvC5MuXaqcSAMREjgw==}
+  miniflare@4.20260603.0:
+    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -461,17 +461,17 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  workerd@1.20260601.1:
-    resolution: {integrity: sha512-Bg4+HF3B8TW0urAv8chiz25HSQ/aJxMBjgheUzu/nB1NQa+CaKGrUPv+Z3bf0np/WxLHYW1kcseVEtzZVPbX4g==}
+  workerd@1.20260603.1:
+    resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.97.0:
-    resolution: {integrity: sha512-jzW/aNvjerV+4TmwbvwGY6lpcuBk7EFUTonMDNfci45wSmMTj2/OJN+83cc/CeepKdb+6ZjGJw9NRjmcQoxqRg==}
+  wrangler@4.98.0:
+    resolution: {integrity: sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260601.1
+      '@cloudflare/workers-types': ^4.20260603.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -498,25 +498,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260601.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260601.1
+      workerd: 1.20260603.1
 
-  '@cloudflare/workerd-darwin-64@1.20260601.1':
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260601.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260601.1':
+  '@cloudflare/workerd-linux-64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260601.1':
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260601.1':
+  '@cloudflare/workerd-windows-64@1.20260603.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -769,12 +769,12 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  miniflare@4.20260601.0:
+  miniflare@4.20260603.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260601.1
+      workerd: 1.20260603.1
       ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -829,24 +829,24 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  workerd@1.20260601.1:
+  workerd@1.20260603.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260601.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260601.1
-      '@cloudflare/workerd-linux-64': 1.20260601.1
-      '@cloudflare/workerd-linux-arm64': 1.20260601.1
-      '@cloudflare/workerd-windows-64': 1.20260601.1
+      '@cloudflare/workerd-darwin-64': 1.20260603.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260603.1
+      '@cloudflare/workerd-linux-64': 1.20260603.1
+      '@cloudflare/workerd-linux-arm64': 1.20260603.1
+      '@cloudflare/workerd-windows-64': 1.20260603.1
 
-  wrangler@4.97.0:
+  wrangler@4.98.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260601.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260601.0
+      miniflare: 4.20260603.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260601.1
+      workerd: 1.20260603.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pulumi/core/package.json
+++ b/pulumi/core/package.json
@@ -2,7 +2,7 @@
   "name": "core",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "24.13.0",
+    "@types/node": "24.13.1",
     "ts-node": "10.9.2",
     "typescript": "6.0.3"
   },

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -13,7 +13,7 @@
     "@eslint/js": "10.0.1",
     "@types/archiver": "7.0.0",
     "@types/folder-hash": "4.0.4",
-    "@types/node": "24.13.0",
+    "@types/node": "24.13.1",
     "@types/readable-stream": "4.0.23",
     "@typescript-eslint/parser": "8.60.1",
     "eslint": "10.4.1",
@@ -38,5 +38,5 @@
     "pino-pretty": "13.1.3",
     "readable-stream": "4.7.0"
   },
-  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/pulumi/pnpm-lock.yaml
+++ b/pulumi/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/aws-native':
         specifier: 1.68.0
-        version: 1.68.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 1.68.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/cloudflare':
         specifier: 6.17.0
-        version: 6.17.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.17.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.245.0
-        version: 3.245.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 3.245.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       '@root/walk':
         specifier: 1.1.0
         version: 1.1.0
@@ -52,8 +52,8 @@ importers:
         specifier: 4.0.4
         version: 4.0.4
       '@types/node':
-        specifier: 24.13.0
-        version: 24.13.0
+        specifier: 24.13.1
+        version: 24.13.1
       '@types/readable-stream':
         specifier: 4.0.23
         version: 4.0.23
@@ -77,7 +77,7 @@ importers:
         version: 3.8.3
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.13.0)(typescript@6.0.3)
+        version: 10.9.2(@types/node@24.13.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -89,17 +89,17 @@ importers:
     dependencies:
       '@pulumi/aws-native':
         specifier: 1.68.0
-        version: 1.68.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 1.68.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.245.0
-        version: 3.245.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+        version: 3.245.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
     devDependencies:
       '@types/node':
-        specifier: 24.13.0
-        version: 24.13.0
+        specifier: 24.13.1
+        version: 24.13.1
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.13.0)(typescript@6.0.3)
+        version: 10.9.2(@types/node@24.13.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -511,11 +511,11 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
-
   '@types/node@24.13.0':
     resolution: {integrity: sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==}
+
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
 
   '@types/readable-stream@4.0.23':
     resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
@@ -1735,9 +1735,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -2194,32 +2191,32 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@pulumi/aws-native@1.68.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/aws-native@1.68.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/cloudflare@6.17.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/cloudflare@6.17.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)
+      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@logdna/tail-file': 2.2.0
@@ -2249,12 +2246,12 @@ snapshots:
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@24.13.0)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@24.13.1)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@pulumi/pulumi@3.245.0(ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@pulumi/pulumi@3.245.0(ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@logdna/tail-file': 2.2.0
@@ -2284,7 +2281,7 @@ snapshots:
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@24.13.0)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@24.13.1)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2352,21 +2349,21 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@24.12.4':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.13.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
 
   '@types/readable-stream@4.0.23':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.0
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
 
   '@types/semver@7.7.1': {}
 
@@ -3341,7 +3338,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       long: 5.3.2
 
   pump@3.0.4:
@@ -3579,14 +3576,14 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-node@10.9.2(@types/node@24.13.0)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@24.13.1)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.13.0
+      '@types/node': 24.13.1
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -3621,8 +3618,6 @@ snapshots:
       - supports-color
 
   typescript@6.0.3: {}
-
-  undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
-http = "=1.4.1"
+http = "=1.4.2"
 rss = "=2.0.13"
 urlencoding = "=2.1.3"
 worker = { version = "=0.8.3", features = ["http"] }

--- a/workers-rssfilter/Cargo.toml
+++ b/workers-rssfilter/Cargo.toml
@@ -54,7 +54,7 @@ matches = "=0.1.10"
 test-case = "=3.3.1"
 test-utils = { path = "../test-utils" }
 url = "=2.5.8"
-wasm-bindgen-test = "=0.3.73"
+wasm-bindgen-test = "=0.3.72"
 filter-rss-feed = { path = "../filter-rss-feed", features = ["testing"] }
 
 # Non-WASM dev dependencies (mockito brings in tokio with networking features

--- a/workers-rssfilter/Cargo.toml
+++ b/workers-rssfilter/Cargo.toml
@@ -17,7 +17,7 @@ console_error_panic_hook = { version = "=0.1.7" }
 filter-rss-feed = { path = "../filter-rss-feed" }
 headers = "=0.4.1"
 headers-accept = "=0.3.0"
-http = "=1.4.1"
+http = "=1.4.2"
 http-body = "=1.0.1"
 http-body-util = { version = "=0.1.3", features = ["full"] }
 log = "=0.4.32"
@@ -54,7 +54,7 @@ matches = "=0.1.10"
 test-case = "=3.3.1"
 test-utils = { path = "../test-utils" }
 url = "=2.5.8"
-wasm-bindgen-test = "=0.3.72"
+wasm-bindgen-test = "=0.3.73"
 filter-rss-feed = { path = "../filter-rss-feed", features = ["testing"] }
 
 # Non-WASM dev dependencies (mockito brings in tokio with networking features


### PR DESCRIPTION
Fixes the CI failures on #1942.

Two problems with the Renovate update:

1. **`http` bumped to `=1.4.2` without re-vendoring `Cargo.lock`.** The lockfile still pinned `1.4.1`, so the `cargo check --locked` build failed (`failed to select a version for the requirement http = "=1.4.2"`). Ran `cargo update -p http --precise 1.4.2`.

2. **`wasm-bindgen-test` bumped to `=0.3.73` in isolation.** That version requires `js-sys 0.3.100` / `wasm-bindgen 0.2.123`, which conflicts with the lockstep-pinned `wasm-bindgen =0.2.122` / `js-sys =0.3.99`. The wasm-bindgen ecosystem is meant to move together via its Renovate group, so this stray bump is reverted back to `=0.3.72`.

`cargo check --locked --all-targets` now passes.

This branch is based on `renovate/all-minor-patch`, so it carries the full dependency update plus the fixes and can replace #1942.

https://claude.ai/code/session_01QQmLSqnxeLpXmNq62N21pW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQmLSqnxeLpXmNq62N21pW)_