### PR TITLE
ci(claude): gate dependency auto-merge on a SAFE review verdict

### DIFF
--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -9,17 +9,13 @@ name: Claude Dependency Review
 # Claude to read the changelog, judge breaking-change impact against the actual
 # codebase, and post a single risk verdict to help the human merge decision.
 #
-# It is also a merge GATE. Renovate auto-merges minor/patch/digest bumps, but
-# only once all required status checks pass. This job emits a machine-readable
-# verdict (the `--json-schema` structured output) and the final "Gate" step
-# turns it into the job's pass/fail: green only when the verdict is "SAFE".
-# Make this job a required status check on the default branch and a dependency
-# bump can auto-merge only with a SAFE verdict; everything else — a non-SAFE
-# verdict, malformed/empty output, or the review erroring/timing out — holds
-# the PR for a human (fail closed). This is strictly stronger than the prior
-# behaviour, where these bumps auto-merged with no review gate at all: the
-# worst case (a prompt-injected SAFE) merely reproduces today's auto-merge,
-# while every other case now blocks.
+# It is also a merge GATE. Renovate auto-merges minor/patch/digest bumps once
+# all required status checks pass. This job emits a machine-readable verdict
+# (the `--json-schema` structured output) and the final "Gate" step turns it
+# into the job's pass/fail: green only when the verdict is "SAFE". Make this a
+# required status check on the default branch and a bump auto-merges only with
+# a SAFE verdict; a non-SAFE verdict, malformed/empty output, or a failed
+# review all hold the PR for a human (fail closed).
 
 on:
   pull_request:
@@ -128,39 +124,29 @@ jobs:
 
             Keep the comment short and skip empty sections — for a routine
             patch/minor bump with no codebase impact, a couple of lines is
-            enough. Start it with a single clear verdict line, one of:
+            enough. Open with a single verdict line, then a per-dependency
+            summary (version delta, bump type, notable changes, and where it is
+            used here) and any concrete action items (e.g. "update call sites in
+            X", "run tests for Y").
 
-              - ✅ Safe to merge — no breaking changes affecting this repo.
-              - ⚠️ Needs attention — <one-line reason>.
-              - 🔴 Breaking / human review needed — <one-line reason>.
+            There are three verdicts. Use the emoji form in the comment and the
+            enum form in the structured output — they MUST match:
 
-            Follow it with a short per-dependency summary (version delta, bump
-            type, notable changes, and where it is used here) and any concrete
-            action items (e.g. "update call sites in X", "run tests for Y").
-            Do not approve or merge anything — leave the decision to a human.
+              - ✅ Safe to merge -> "SAFE": no breaking changes affecting this
+                repo. This is the ONLY verdict that lets the bump auto-merge.
+              - ⚠️ Needs attention -> "ATTENTION": <one-line reason>.
+              - 🔴 Breaking / human review -> "BREAKING": <one-line reason>.
 
-            Finally — and this is what actually gates the merge — return your
-            machine-readable verdict as this job's structured output. The schema
-            requires `verdict` and `reason`. Map `verdict` from the comment's
-            verdict line:
+            "ATTENTION" and "BREAKING" both hold the PR for a human, which is
+            the safe default — when unsure, do not return "SAFE", and never
+            merge or approve yourself. Return the verdict and a one-sentence
+            `reason` as this job's structured output (the schema's required
+            fields); the gate reads it to decide whether auto-merge proceeds.
 
-              - ✅ Safe to merge          -> "SAFE"
-              - ⚠️ Needs attention        -> "ATTENTION"
-              - 🔴 Breaking / human review -> "BREAKING"
-
-            Only "SAFE" lets the bump auto-merge; "ATTENTION" and "BREAKING"
-            both hold the PR for a human, which is the safe default. When you
-            are unsure, do NOT return "SAFE". Keep `reason` to one short
-            sentence. Your structured verdict MUST agree with the verdict line
-            in the comment you posted.
-
-      # Fail-closed merge gate. Turns the review's structured verdict into this
-      # job's pass/fail so it can be required in branch protection. Green only
-      # on "SAFE"; a non-SAFE verdict, malformed/empty output, or a failed
-      # review step (always() runs us even then) all exit non-zero and hold the
-      # PR. The verdict is read via an env var and never interpolated straight
-      # into the script, so attacker-influenced text in the output cannot break
-      # out of the shell.
+      # Turns the review's structured verdict into this job's pass/fail so it
+      # can be required in branch protection. Exits non-zero unless the verdict
+      # is "SAFE"; always() so a failed review step still reports. The verdict
+      # is read via an env var rather than interpolated into the run script.
       - name: Gate auto-merge on a SAFE verdict
         if: always()
         env:

--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -53,9 +53,11 @@ jobs:
           # "dependabot" matches dependabot[bot].
           allowed_bots: "laneybot,dependabot"
           # This runs in agent mode, so the action does not auto-post Claude's
-          # output — Claude must post it itself. Grant gh pr comment for that
-          # (gh is authenticated in the tool environment). use_sticky_comment
-          # has no effect in agent mode; stickiness is handled via gh below.
+          # output — Claude must post it itself. The tools are read-only plus
+          # `gh pr comment` (gh is authenticated in the tool environment) and
+          # `npm view` for published-package metadata; there is deliberately no
+          # approve or merge tool. use_sticky_comment has no effect in agent
+          # mode; stickiness is handled via gh below.
           #
           # --json-schema constrains Claude's final message to validated JSON,
           # surfaced as steps.<id>.outputs.structured_output for the Gate step
@@ -64,8 +66,8 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6 --max-turns 30 --allowedTools
             "Read,Glob,Grep,WebFetch,Bash(gh pr view:*),Bash(gh pr
-            diff:*),Bash(gh api:*),Bash(gh pr comment:*)" --json-schema
-            '{"type":"object","additionalProperties":false,"properties":{"verdict":{"type":"string","enum":["SAFE","ATTENTION","BREAKING"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
+            diff:*),Bash(gh pr comment:*),Bash(npm view:*)" --json-schema
+            '{"type":"object","additionalProperties":false,"properties":{"verdict":{"type":"string","enum":["SAFE","ATTENTION","BREAKING","UNKNOWN"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
           prompt: |
             You are reviewing a dependency-update pull request in the
             iainlane/rssfilter repository: ${{ github.repository }} PR
@@ -106,10 +108,16 @@ jobs:
                the workspace packages, Rust crates, Pulumi, workflows). Judge
                the *real* impact here — a breaking change in an unused code
                path does not matter; one in hot code does.
-            6. Note any security relevance: CVE fixes (a reason to merge) or
-               supply-chain red flags on a "patch" bump (unexpected new
-               install scripts, large size growth, publisher change,
-               typosquatting) — a reason for caution.
+            6. For npm packages, inspect the *published* artefact's metadata
+               for the exact new version — the registry package, not the source
+               repo, is what actually gets installed. Run
+               `npm view <name>@<version> .maintainers .scripts dist.integrity
+               dist.unpackedSize dist-tags` and flag supply-chain red flags a
+               changelog would not mention: new or changed maintainers, newly
+               added install/preinstall/postinstall scripts, a large jump in
+               unpacked size, or a typosquatted name. (Metadata only — do not
+               download, install, or run the package.) CVE fixes are a reason to
+               merge; these are reasons for caution.
 
             Then you MUST post your findings as a comment on the PR — this is
             the whole point of the job, and nothing posts it for you. Post
@@ -129,19 +137,22 @@ jobs:
             used here) and any concrete action items (e.g. "update call sites in
             X", "run tests for Y").
 
-            There are three verdicts. Use the emoji form in the comment and the
+            There are four verdicts. Use the emoji form in the comment and the
             enum form in the structured output — they MUST match:
 
-              - ✅ Safe to merge -> "SAFE": no breaking changes affecting this
-                repo. This is the ONLY verdict that lets the bump auto-merge.
+              - ✅ Safe to merge -> "SAFE": no breaking changes or supply-chain
+                concerns affecting this repo. The ONLY verdict that auto-merges.
               - ⚠️ Needs attention -> "ATTENTION": <one-line reason>.
               - 🔴 Breaking / human review -> "BREAKING": <one-line reason>.
+              - ❓ Could not assess -> "UNKNOWN": <one-line reason> (e.g. a
+                changelog or registry you could not reach, or you ran out of
+                steps before reaching a conclusion).
 
-            "ATTENTION" and "BREAKING" both hold the PR for a human, which is
-            the safe default — when unsure, do not return "SAFE", and never
-            merge or approve yourself. Return the verdict and a one-sentence
-            `reason` as this job's structured output (the schema's required
-            fields); the gate reads it to decide whether auto-merge proceeds.
+            Anything other than "SAFE" holds the PR for a human — the safe
+            default — so when you cannot confirm a bump is safe, do not force
+            "SAFE". Return the verdict and a one-sentence `reason` as this job's
+            structured output (the schema's required fields); the gate reads it
+            to decide whether auto-merge proceeds.
 
       # Turns the review's structured verdict into this job's pass/fail so it
       # can be required in branch protection. Exits non-zero unless the verdict

--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -68,8 +68,8 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6 --max-turns 30 --allowedTools
             "Read,Glob,Grep,WebFetch,Bash(gh pr view:*),Bash(gh pr
-            diff:*),Bash(gh api:*),Bash(gh pr comment:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"verdict":{"type":"string","enum":["SAFE","ATTENTION","BREAKING"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
+            diff:*),Bash(gh api:*),Bash(gh pr comment:*)" --json-schema
+            '{"type":"object","additionalProperties":false,"properties":{"verdict":{"type":"string","enum":["SAFE","ATTENTION","BREAKING"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
           prompt: |
             You are reviewing a dependency-update pull request in the
             iainlane/rssfilter repository: ${{ github.repository }} PR
@@ -164,7 +164,8 @@ jobs:
       - name: Gate auto-merge on a SAFE verdict
         if: always()
         env:
-          STRUCTURED_OUTPUT: ${{ steps.claude-dependency-review.outputs.structured_output }}
+          STRUCTURED_OUTPUT:
+            ${{ steps.claude-dependency-review.outputs.structured_output }}
         run: |
           verdict="$(jq -r '.verdict // "MISSING"' <<<"${STRUCTURED_OUTPUT:-{}}" 2>/dev/null || echo "MALFORMED")"
           echo "Dependency review verdict: ${verdict}"

--- a/.github/workflows/claude-dependency-review.yml
+++ b/.github/workflows/claude-dependency-review.yml
@@ -8,6 +8,18 @@ name: Claude Dependency Review
 # This workflow runs instead for PRs opened by our dependency bots and asks
 # Claude to read the changelog, judge breaking-change impact against the actual
 # codebase, and post a single risk verdict to help the human merge decision.
+#
+# It is also a merge GATE. Renovate auto-merges minor/patch/digest bumps, but
+# only once all required status checks pass. This job emits a machine-readable
+# verdict (the `--json-schema` structured output) and the final "Gate" step
+# turns it into the job's pass/fail: green only when the verdict is "SAFE".
+# Make this job a required status check on the default branch and a dependency
+# bump can auto-merge only with a SAFE verdict; everything else — a non-SAFE
+# verdict, malformed/empty output, or the review erroring/timing out — holds
+# the PR for a human (fail closed). This is strictly stronger than the prior
+# behaviour, where these bumps auto-merged with no review gate at all: the
+# worst case (a prompt-injected SAFE) merely reproduces today's auto-merge,
+# while every other case now blocks.
 
 on:
   pull_request:
@@ -48,10 +60,16 @@ jobs:
           # output — Claude must post it itself. Grant gh pr comment for that
           # (gh is authenticated in the tool environment). use_sticky_comment
           # has no effect in agent mode; stickiness is handled via gh below.
+          #
+          # --json-schema constrains Claude's final message to validated JSON,
+          # surfaced as steps.<id>.outputs.structured_output for the Gate step
+          # below. Keep the schema on a single physical line: this is a folded
+          # (>-) scalar, so line breaks become spaces.
           claude_args: >-
             --model claude-sonnet-4-6 --max-turns 30 --allowedTools
             "Read,Glob,Grep,WebFetch,Bash(gh pr view:*),Bash(gh pr
             diff:*),Bash(gh api:*),Bash(gh pr comment:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"verdict":{"type":"string","enum":["SAFE","ATTENTION","BREAKING"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
           prompt: |
             You are reviewing a dependency-update pull request in the
             iainlane/rssfilter repository: ${{ github.repository }} PR
@@ -120,3 +138,38 @@ jobs:
             type, notable changes, and where it is used here) and any concrete
             action items (e.g. "update call sites in X", "run tests for Y").
             Do not approve or merge anything — leave the decision to a human.
+
+            Finally — and this is what actually gates the merge — return your
+            machine-readable verdict as this job's structured output. The schema
+            requires `verdict` and `reason`. Map `verdict` from the comment's
+            verdict line:
+
+              - ✅ Safe to merge          -> "SAFE"
+              - ⚠️ Needs attention        -> "ATTENTION"
+              - 🔴 Breaking / human review -> "BREAKING"
+
+            Only "SAFE" lets the bump auto-merge; "ATTENTION" and "BREAKING"
+            both hold the PR for a human, which is the safe default. When you
+            are unsure, do NOT return "SAFE". Keep `reason` to one short
+            sentence. Your structured verdict MUST agree with the verdict line
+            in the comment you posted.
+
+      # Fail-closed merge gate. Turns the review's structured verdict into this
+      # job's pass/fail so it can be required in branch protection. Green only
+      # on "SAFE"; a non-SAFE verdict, malformed/empty output, or a failed
+      # review step (always() runs us even then) all exit non-zero and hold the
+      # PR. The verdict is read via an env var and never interpolated straight
+      # into the script, so attacker-influenced text in the output cannot break
+      # out of the shell.
+      - name: Gate auto-merge on a SAFE verdict
+        if: always()
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.claude-dependency-review.outputs.structured_output }}
+        run: |
+          verdict="$(jq -r '.verdict // "MISSING"' <<<"${STRUCTURED_OUTPUT:-{}}" 2>/dev/null || echo "MALFORMED")"
+          echo "Dependency review verdict: ${verdict}"
+          if [ "${verdict}" != "SAFE" ]; then
+            echo "::error::Dependency review did not return SAFE (got '${verdict}'); holding the PR for a human. Review the verdict comment and merge manually if appropriate."
+            exit 1
+          fi
+          echo "Verdict is SAFE; auto-merge may proceed."


### PR DESCRIPTION
## What

Turns the **Claude Dependency Review** job into a merge gate, so Renovate's minor/patch/digest auto-merges only land when Claude returns a `SAFE` verdict.

- Claude emits a validated verdict via `--json-schema` → `steps.<id>.outputs.structured_output` (`verdict` ∈ `SAFE` | `ATTENTION` | `BREAKING`, plus a one-line `reason`). It still posts the human-readable comment.
- A final `Gate` step maps that verdict to the job's exit code: green only on `SAFE`. The verdict is read via an env var rather than interpolated into the run script.
- Fail-closed: a non-`SAFE` verdict, malformed/empty output, or a failed/timed-out review all leave the check red and hold the PR (`if: always()` so the gate still reports on a failed review).

The structured output is shape-validated, not truth-validated — it's an LLM judgement over untrusted input, suited as a breaking-change safety net. Defense against a malicious upstream stays with SHA/digest pinning, `actions-rust-lang/audit`, OSV alerts, and human merge for majors.

## Required follow-up (manual)

The gate only blocks once it's a **required status check**. In Settings → Branches → branch protection for `main`, add the check named **`dependency-review`** (*Claude Dependency Review / dependency-review*). Renovate's `automerge` then waits on it; no `renovate-config.json5` change needed.

For human-authored PRs this job is skipped (bot-only `if:`), which branch protection treats as neutral, so it won't block normal PRs.

## Notes

- Confirm the pinned action version (`v1.0.140`) accepts `--json-schema`; bump `anthropics/claude-code-action` if not.
- Scope includes **minor**, alongside patch/digest.

https://claude.ai/code/session_01JxPT4yWfonVPsgTzELEMpY