### PR TITLE
ci(renovate): group wasm-bindgen-test with the wasm-bindgen update group

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -42,6 +42,17 @@
       matchManagers: ["cargo"],
     },
     {
+      // wasm-bindgen-test lives in the wasm-bindgen monorepo, so the
+      // matchSourceUrls rule above should already group it. Match it by name as
+      // well to guarantee it: each wasm-bindgen-test patch exact-pins the
+      // matching js-sys/wasm-bindgen versions, so if it lags behind the rest of
+      // the group the versions conflict and Renovate can't regenerate
+      // Cargo.lock, producing a PR that fails to build (see #1945).
+      groupName: "wasm-bindgen and cloudflare-workers",
+      matchPackageNames: ["wasm-bindgen-test"],
+      matchManagers: ["cargo"],
+    },
+    {
       groupName: "tracing",
       matchPackageNames: ["tracing*", "opentelemetry*"],
       matchManagers: ["cargo"],


### PR DESCRIPTION
## Why

PR #1945 (a Renovate group update) merged with a broken state that needed a manual lockfile fix. The root cause: Renovate bumped `wasm-bindgen` → `0.2.123` and `js-sys` → `0.3.100`, but left `wasm-bindgen-test` pinned at `=0.3.72`.

Each `wasm-bindgen-test` patch release exact-pins the matching `js-sys`/`wasm-bindgen` versions. `wasm-bindgen-test 0.3.72` requires `js-sys =0.3.99`, which then conflicts with `js-sys =0.3.100`. That conflict prevented Renovate from regenerating `Cargo.lock`, so the PR shipped a stale lock (`worker 0.8.3`) and failed to build in the Nix/crane vendored path:

```
error: failed to select a version for the requirement `worker = "=0.8.4"`
candidate versions found which didn't match: 0.8.3
perhaps a crate was updated and forgotten to be re-vendored?
```

## What

Add an explicit `matchPackageNames: ["wasm-bindgen-test"]` rule to the existing **wasm-bindgen and cloudflare-workers** group. `wasm-bindgen-test` lives in the wasm-bindgen monorepo, so the existing `matchSourceUrls` rule should already catch it — but it demonstrably lagged behind in #1945, so this belt-and-suspenders name match guarantees it's always bumped in lockstep with the rest of the group (and the lockfile resolves), regardless of crates.io source-URL metadata quirks.

Validated with `renovate-config-validator` (`Config validated successfully`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01M84WCUQuQ81Wc8BfVwpez5)_