### PR TITLE
chore(deps): pin eslint-plugin-unicorn to numbered release 65.0.1

### DIFF
--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -19,7 +19,7 @@
     "eslint": "10.4.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "github:sindresorhus/eslint-plugin-unicorn#6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a",
+    "eslint-plugin-unicorn": "65.0.1",
     "prettier": "3.8.4",
     "ts-node": "10.9.2",
     "typescript": "6.0.3",

--- a/pulumi/pnpm-lock.yaml
+++ b/pulumi/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: 5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.4.1))(eslint@10.4.1)(prettier@3.8.4)
       eslint-plugin-unicorn:
-        specifier: github:sindresorhus/eslint-plugin-unicorn#6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a
-        version: https://codeload.github.com/sindresorhus/eslint-plugin-unicorn/tar.gz/6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a(eslint@10.4.1)
+        specifier: 65.0.1
+        version: 65.0.1(eslint@10.4.1)
       prettier:
         specifier: 3.8.4
         version: 3.8.4
@@ -895,12 +895,11 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-unicorn@https://codeload.github.com/sindresorhus/eslint-plugin-unicorn/tar.gz/6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a:
-    resolution: {gitHosted: true, integrity: sha512-+ayQ7FqGm/vZ29zpgD/OmO7eoMjSWb1oet0rqYkE2GJrp1FtEI+Ph3584LGDG5yKAmE8dllZxwxT+I2QE+rLHw==, tarball: https://codeload.github.com/sindresorhus/eslint-plugin-unicorn/tar.gz/6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a}
-    version: 65.0.1
-    engines: {node: '>=22'}
+  eslint-plugin-unicorn@65.0.1:
+    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
+    engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
-      eslint: '>=10.4'
+      eslint: '>=9.38.0'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -2723,11 +2722,10 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.4.1)
 
-  eslint-plugin-unicorn@https://codeload.github.com/sindresorhus/eslint-plugin-unicorn/tar.gz/6b6ab55cf5ce77deaf8694325bb7cb2a6a9e2d0a(eslint@10.4.1):
+  eslint-plugin-unicorn@65.0.1(eslint@10.4.1):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
-      browserslist: 4.28.2
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0


### PR DESCRIPTION
## Why we were on a SHA

`pulumi/package.json` pinned `eslint-plugin-unicorn` to a git commit on upstream `main` (`github:sindresorhus/eslint-plugin-unicorn#…`). The repo history was squashed, so the original decision isn't in the commit log, but the evidence reconstructs it: the first pinned commit (`4fd8dd5a`) is listed in unicorn's **v65.0.0** release notes. We were tracking unreleased `main` to get changes that hadn't shipped in a numbered release yet (the latest published at the time was v64.0.0; v65.0.0 didn't land until 2026-06-07). The likely driver was ESLint 10 support — we run `eslint 10.4.1`.

## Why we don't need it anymore

The work we were tracking is now released. **v65.0.1** (2026-06-08) includes that commit and declares `eslint` peer `>=9.38.0`, which our `eslint 10.4.1` satisfies.

## Change

- Pin `eslint-plugin-unicorn` to `65.0.1` (was a moving git SHA)
- Refresh `pulumi/pnpm-lock.yaml`

This stops the recurring Renovate **digest-update** PRs (e.g. #1970) and restores normal version-based updates.

## Verification

- `pnpm install` resolves `eslint-plugin-unicorn@65.0.1(eslint@10.4.1)`
- `eslint .` in `pulumi/` produces the same single **pre-existing** error (`@typescript-eslint/no-unnecessary-condition` in `dns-tls.ts`, unrelated to unicorn); unicorn loads and our `unicorn/no-typeof-undefined` rule applies as before.

Supersedes #1970.

https://claude.ai/code/session_012C3Mc4GkT8UhGjZ4hv9TEn

---
_Generated by [Claude Code](https://claude.ai/code/session_012C3Mc4GkT8UhGjZ4hv9TEn)_