### PR TITLE
ci(renovate): group wasm-bindgen family by package name

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -42,6 +42,28 @@
       matchManagers: ["cargo"],
     },
     {
+      // Match the wasm-bindgen family by name in addition to the
+      // matchSourceUrls rule above. These crates are pinned with `=` and
+      // must move in lockstep. matchSourceUrls proved unreliable here:
+      // although wasm-bindgen-test reports the same repository
+      // (github.com/wasm-bindgen/wasm-bindgen) as the rest of the family,
+      // it was not grouped with them (it was published ahead of the others
+      // and an earlier run swept it into group:allNonMajor instead). The
+      // split left the workspace Cargo.lock unresolvable from either PR.
+      // Matching by name doesn't rely on sourceUrl resolution, so the
+      // family always groups together.
+      groupName: "wasm-bindgen and cloudflare-workers",
+      matchPackageNames: [
+        "wasm-bindgen",
+        "wasm-bindgen-cli",
+        "wasm-bindgen-test",
+        "wasm-bindgen-futures",
+        "js-sys",
+        "web-sys",
+      ],
+      matchManagers: ["cargo", "custom.regex"],
+    },
+    {
       groupName: "tracing",
       matchPackageNames: ["tracing*", "opentelemetry*"],
       matchManagers: ["cargo"],


### PR DESCRIPTION
## Why

PRs #1992 and #1994 both got stuck with `Cargo.lock` artifact-update failures and couldn't auto-merge. Root cause: the wasm-bindgen family (`wasm-bindgen`, `wasm-bindgen-cli`, `wasm-bindgen-test`, `js-sys`) is pinned with `=` across the workspace and must move in lockstep, but Renovate split it across two PRs:

- #1994 ("wasm-bindgen and cloudflare-workers") got `js-sys`/`wasm-bindgen`/`wasm-bindgen-cli` → `0.3.103`/`0.2.126`
- #1992 ("all non-major") got `wasm-bindgen-test` → `0.3.76`

With the pins split, neither PR could regenerate the workspace `Cargo.lock`: `wasm-bindgen-test 0.3.76` needs `js-sys 0.3.103`, but `js-sys` was still pinned `=0.3.102` (and vice-versa).

The group was defined **only** via `matchSourceUrls`. Every crate in the family — including `wasm-bindgen-test` — reports the same repository (`https://github.com/wasm-bindgen/wasm-bindgen`) on crates.io, so `matchSourceUrls` *should* have grouped them all. But `wasm-bindgen-test 0.3.76` was published ahead of the rest of the family, and an earlier Renovate run (PR #1992 was opened ~3.5h before #1994) swept it into the catch-all `group:allNonMajor` instead. So `matchSourceUrls` is unreliable here despite correct metadata.

## What

Add an explicit `matchPackageNames` rule for the family so grouping no longer depends on sourceUrl resolution. From now on all crates land in a single PR and the lockfile stays resolvable.

## Follow-up

Once this merges, Renovate will regenerate the affected PRs correctly on its next run: `wasm-bindgen-test` will move into the wasm-bindgen group so #1994 carries the full coherent family (and resolves), and #1992 drops it. No manual edits to the Renovate branches are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)