### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Bumps `quinn-proto` `0.11.14` → `0.11.15` in `Cargo.lock` to clear **RUSTSEC-2026-0185** (GHSA-4w2j-m93h-cj5j).

## Why

The daily **Audit Rust Dependencies** workflow has been failing on every run (e.g. [run 28179881884](https://github.com/iainlane/rssfilter/actions/runs/28179881884)) because `cargo-audit` flags one entry:

- **RUSTSEC-2026-0185** — *Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly* (network-triggerable DoS), published 2026-06-22. Fixed in `0.11.15`.

`quinn-proto` is a **transitive** dependency — `filter-rss-feed → reqwest → quinn → quinn-proto` (also via `rssfilter-telemetry → opentelemetry-otlp → opentelemetry-http → reqwest`). There is no `quinn-proto` entry in any `Cargo.toml`, so the fix is a lockfile-only change. Renovate doesn't open vulnerability-fix PRs for lockfile-only transitive bumps, which is why the audit kept failing with no corresponding Renovate PR — the `lockFileMaintenance` weekly job would have eventually swept it in, but hadn't run since the advisory landed.

## How

`0.11.15` is a semver-compatible patch within the range `quinn` already allows, so:

```
cargo update -p quinn-proto --precise 0.11.15
```

Only `quinn-proto` changes (version + checksum); nothing else in the lockfile moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FtBGns7MAYbkTiDqkwUUW)_